### PR TITLE
fixup version parsing with extra whitespace

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -142,8 +142,13 @@ impl FromStr for VersionRequirement {
             }
             if c == ' ' {
                 // we should have the op in current
-                op = Some(Operator::from_str(&current).expect("TODO"));
-                current = String::new();
+                // however formatting across lines can sometimes cause multiple whitespaces
+                // after the op like "(>=   1.2.0)"
+                // so if we hit more whitespace after setting the op we can just continue
+                if op.is_none() {
+                    op = Some(Operator::from_str(&current).expect("TODO"));
+                    current = String::new();
+                }
                 continue;
             }
             if c == ')' {
@@ -175,6 +180,7 @@ mod tests {
         let inputs = vec![
             "(> 1.0.0)",
             "(>= 1.0)",
+            "(>=    1.0)", // extra whitespace
             "(== 1.7-7-1)",
             "(<= 2023.8.2.1)",
             "(< 1.0-10)",


### PR DESCRIPTION
testing this on the new rv-test-snapshot repo caused a panic with the version parsing, when investigating it shows from the places where there is a linebreak:

```

Package: bbr
Version: 1.12.0
Depends: R (>= 3.5)
Imports: callr, checkmate, cli (>= 3.1.0), data.table, digest, diffobj, dplyr (>= 1.0.0), fs (>=
          1.4.2), glue, jsonlite, lifecycle, magrittr, mrgmisc, nmrec (>= 0.3.0), processx,
          purrr (>= 1.0.0), readr, rlang, stringfish, stringr, tibble, tidyr, tidyselect (>=
          1.0.0), xfun, yaml
Suggests: collapsibleTree (>= 0.1.7), covr, devtools, forcats, ggplot2, grid, htmlwidgets,
          knitr, png, rmarkdown, rprojroot, scales, testthat (>= 2.1.0), webshot, withr (>=
          2.4.0)
License: MIT + file LICENSE
MD5sum: 11fcde14ce656234ed4a423e0285ef1e
NeedsCompilation: no
```

becomes  `fs (>=          1.4.2)` so we'll just keep trimming after a version constraint til we get a number now
