### PR TITLE
fix: binary urls for linux for non package manager urls

### DIFF
--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -133,7 +133,7 @@ fn load_databases(
                         &cache.r_version,
                         &cache.system_info,
                     );
-
+                    log::debug!("checking for binary packages URL: {:?}", binary_url);
                     // we do not know for certain that the Some return of get_binary_path will be a valid url,
                     // but we do know that if it returns None there is not a binary PACKAGES file
                     if let Some(url) = binary_url {

--- a/src/repo_path.rs
+++ b/src/repo_path.rs
@@ -237,7 +237,18 @@ impl<'a> RepoServer<'a> {
                 get_distro_name(sysinfo, distro)?, //need to determine if RV will have same binary support/distro names
                 Self::extract_snapshot_date(url)?
             ),
-            _ => return None,
+            Self::Other(url) => {
+                //TODO: we cannot expect only snapshot date/latest pattern for other/RV/PRISM in the future
+                // but this unblocks some work right now
+                let snapshot_date  = Self::extract_snapshot_date(url)?;
+                let trimmed_url = url.trim_end_matches(snapshot_date).trim_end_matches("/");
+                format!(
+                "{}/__linux__/{}/{}/src/contrib",
+                trimmed_url,
+                get_distro_name(sysinfo, distro)?, //need to determine if RV will have same binary support/distro names
+                snapshot_date 
+            )
+        },
         };
 
         // binaries are only returned when query strings are set for the r version


### PR DESCRIPTION
This logic still needs additional refactoring for the prism/future design of wanting "other" to support non date based patterns of naming, but this works for PPM urls now.

In addition, in looking at this, we'll also need to change the PPM logic to be more flexible - the packagemanager.posit.co/cran really is just _public_ posit package manager, but also we need to support private package manager urls as well.