### PR TITLE
Verify r version matches during activate

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -74,10 +74,23 @@ pub(crate) const GLOBAL_ACTIVATE_FILE_CONTENT: &str = r#"local({
 		}
 		.libPaths(rv_lib, include.site = FALSE)
 	}
+	if (interactive()) {
+		# Extract the R version from rv for comparison with the local R version
+		rv_info <- system2("rv", "info --r-version", stdout = TRUE)
+		if (!is.null(attr(rv_info, "status"))) {
+			# if system2 fails it'll add a status attrivute with the error code
+			warning("failed to run rv info, check your console for messages")
+		} else {
+			sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
+			r_matches <- sys_r |> 
+				grepl(pattern = paste0("^", rv_info))
+		}
+		message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
+		if (!r_matches) {
+			message(sprintf("\nWARNING: R version specified in config (%s) does not match session version (%s)", rv_info, sys_r))
+		}
+	}
 })
-if (interactive()) {
-	message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
-}
 "#;
 
 pub(crate) const PROJECT_ACTIVATE_FILE_CONTENT: &str = r#"local({
@@ -95,8 +108,21 @@ pub(crate) const PROJECT_ACTIVATE_FILE_CONTENT: &str = r#"local({
 		}
 		.libPaths(rv_lib, include.site = FALSE)
 	}
+	if (interactive()) {
+		# Extract the R version from rv for comparison with the local R version
+		rv_info <- system2("rv", "info --r-version", stdout = TRUE)
+		if (!is.null(attr(rv_info, "status"))) {
+			# if system2 fails it'll add a status attrivute with the error code
+			warning("failed to run rv info, check your console for messages")
+		} else {
+			sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
+			r_matches <- sys_r |> 
+				grepl(pattern = paste0("^", rv_info))
+		}
+		message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
+		if (!r_matches) {
+			message(sprintf("\nWARNING: R version specified in config (%s) does not match session version (%s)", rv_info, sys_r))
+		}
+	}
 })
-if (interactive()) {
-	message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
-}
 "#;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -76,14 +76,13 @@ pub(crate) const GLOBAL_ACTIVATE_FILE_CONTENT: &str = r#"local({
 	}
 	if (interactive()) {
 		# Extract the R version from rv for comparison with the local R version
-		rv_info <- system2("rv", "info --r-version", stdout = TRUE)
+		rv_info <- system2("rv", c("info", "--r-version"), stdout = TRUE)
 		if (!is.null(attr(rv_info, "status"))) {
 			# if system2 fails it'll add a status attrivute with the error code
 			warning("failed to run rv info, check your console for messages")
 		} else {
 			sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
-			r_matches <- sys_r |> 
-				grepl(pattern = paste0("^", rv_info))
+			r_matches <- grepl(paste0("^", rv_info), sys_r)
 		}
 		message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
 		if (!r_matches) {
@@ -110,14 +109,13 @@ pub(crate) const PROJECT_ACTIVATE_FILE_CONTENT: &str = r#"local({
 	}
 	if (interactive()) {
 		# Extract the R version from rv for comparison with the local R version
-		rv_info <- system2("rv", "info --r-version", stdout = TRUE)
+		rv_info <- system2("rv", c("info", "--r-version"), stdout = TRUE)
 		if (!is.null(attr(rv_info, "status"))) {
 			# if system2 fails it'll add a status attrivute with the error code
 			warning("failed to run rv info, check your console for messages")
 		} else {
 			sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
-			r_matches <- sys_r |> 
-				grepl(pattern = paste0("^", rv_info))
+			r_matches <- grepl(paste0("^", rv_info), sys_r)
 		}
 		message("rv libpaths active!\nlibrary paths: \n", paste0("  ", .libPaths(), collapse = "\n"))
 		if (!r_matches) {

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,7 +95,7 @@ fn clone_repository(
     // If the destination exists, open the repo and fetch instead but only if we can't find the ref
     let repo = if destination.exists() {
         log::debug!("Repo {url} found in cache.");
-        
+
         Repository::open(destination)?
     } else {
         log::debug!("Repo {url} not found in cache. Cloning.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,18 @@ pub enum Command {
     },
     /// Replaces the library with exactly what is in the lock file
     Sync,
+<<<<<<< HEAD
     /// Provide infomration about the project
     Info {
         #[clap(short, long)]
         json: bool,
+=======
+    /// Provide information about the project
+    Info {
+        #[clap(short, long)]
+        /// Display only the r version
+        r_version: bool,
+>>>>>>> 95710f7 (minimal info + verifying r version matches config)
     },
     /// Gives information about where the cache is for that project
     Cache {
@@ -264,6 +272,13 @@ fn try_main() -> Result<()> {
                 cli.verbose.is_present(),
                 SyncMode::FullUpgrade,
             )?;
+        }
+        Command::Info { r_version } => {
+            let context = CliContext::new(&cli.config_file)?;
+
+            if r_version {
+                println!("{}", context.config.r_version());
+            }
         }
         Command::Cache { json } => {
             let context = CliContext::new(&cli.config_file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ fn try_main() -> Result<()> {
             let path_out = if cfg!(windows) {
                 path_str.replace('\\', "/")
             } else {
-              path_str.to_string()
+                path_str.to_string()
             };
             println!("{path_out}");
         }
@@ -320,12 +320,23 @@ fn try_main() -> Result<()> {
                 context.lockfile.as_ref(),
             );
             if json {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&info).expect("valid json")
-                );
+                if r_version {
+                    println!(
+                        "{}",
+                        serde_json::json!({"r_version": context.config.r_version().original})
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&info).expect("valid json")
+                    );
+                }
             } else {
-                println!("{info}");
+                if r_version {
+                    println!("{}", context.config.r_version().original);
+                } else {
+                    println!("{info}");
+                }
             }
         }
         Command::Activate => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,18 +47,13 @@ pub enum Command {
     },
     /// Replaces the library with exactly what is in the lock file
     Sync,
-<<<<<<< HEAD
-    /// Provide infomration about the project
-    Info {
-        #[clap(short, long)]
-        json: bool,
-=======
     /// Provide information about the project
     Info {
         #[clap(short, long)]
+        json: bool,
+        #[clap(short, long)]
         /// Display only the r version
         r_version: bool,
->>>>>>> 95710f7 (minimal info + verifying r version matches config)
     },
     /// Gives information about where the cache is for that project
     Cache {
@@ -273,13 +268,6 @@ fn try_main() -> Result<()> {
                 SyncMode::FullUpgrade,
             )?;
         }
-        Command::Info { r_version } => {
-            let context = CliContext::new(&cli.config_file)?;
-
-            if r_version {
-                println!("{}", context.config.r_version());
-            }
-        }
         Command::Cache { json } => {
             let context = CliContext::new(&cli.config_file)?;
             let info = CacheInfo::new(
@@ -318,7 +306,7 @@ fn try_main() -> Result<()> {
                 }
             }
         }
-        Command::Info { json } => {
+        Command::Info { json, r_version } => {
             let mut context = CliContext::new(&cli.config_file)?;
             context.load_databases()?;
             let resolved = resolve_dependencies(&context);

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -72,9 +72,16 @@ pub fn find_r_version_command(r_version: &Version) -> Option<RCommandLine> {
 
     // For windows, R installed/managed by rig is has the extension .bat
     if cfg!(windows) {
-        if does_r_cmd_match_version(&RCommandLine {r: Some(PathBuf::from("R.bat"))}, r_version) {
+        if does_r_cmd_match_version(
+            &RCommandLine {
+                r: Some(PathBuf::from("R.bat")),
+            },
+            r_version,
+        ) {
             log::debug!("R {r_version} found on the path from `rig`");
-            return Some(RCommandLine { r: Some(PathBuf::from("R.bat")) })
+            return Some(RCommandLine {
+                r: Some(PathBuf::from("R.bat")),
+            });
         }
     }
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -134,7 +134,9 @@ impl<'d> Resolver<'d> {
         } else if canon_path.is_dir() {
             // we have a folder
             parse_description_file_in_folder(&canon_path)?
-        } else {unreachable!()};
+        } else {
+            unreachable!()
+        };
 
         let (resolved_dep, deps) = ResolvedDependency::from_local_package(
             &package,


### PR DESCRIPTION
Minimal `rv info` with `--r-version` flag to allow for easy R version comparison