### PR TITLE
add missing case for counts in cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ pub enum Command {
         #[clap(long, value_parser, num_args = 1..)]
         add: Vec<String>,
     },
-    /// Returns the path for the library for the current project/system
+    /// Returns the path for the library for the current project/system. 
     /// The path is always in unix format
     Library,
     /// Dry run of what sync would do

--- a/src/project_info.rs
+++ b/src/project_info.rs
@@ -382,7 +382,7 @@ impl Counts {
             // Other fields are updated agnostic to if the dep is from binary or not
             counts.to_install += 1;
             match dep.status {
-                DependencyStatus::InCache => counts.in_cache += 1,
+                DependencyStatus::InCache | DependencyStatus::ToCompile => counts.in_cache += 1,
                 DependencyStatus::Missing => counts.to_download += 1,
                 _ => (),
             }


### PR DESCRIPTION
In the `Counts` struct, the value `in_cache` should count packages that are both in the cache as compiled binaries and as compilation required. `DependencyStatus::ToCompile` represents packages in cache that need to be compiled and were not adding to `in_cache`. This PR fixes that