### PR TITLE
Renv Migration Improvement

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -157,7 +157,7 @@ fn create_library_structure(project_directory: impl AsRef<Path>) -> Result<(), I
     })
 }
 
-fn create_gitignore(project_directory: impl AsRef<Path>) -> Result<(), InitError> {
+pub fn create_gitignore(project_directory: impl AsRef<Path>) -> Result<(), InitError> {
     let path = project_directory.as_ref().join(GITIGNORE_PATH);
     if path.exists() {
         return Ok(());

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -147,7 +147,7 @@ pub fn find_r_repositories() -> Result<Vec<Repository>, InitError> {
         .collect::<Vec<_>>())
 }
 
-fn create_library_structure(project_directory: impl AsRef<Path>) -> Result<(), InitError> {
+pub fn create_library_structure(project_directory: impl AsRef<Path>) -> Result<(), InitError> {
     let lib_dir = project_directory.as_ref().join(LIBRARY_PATH);
     if lib_dir.is_dir() {
         return Ok(());

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,5 @@
 mod init;
 mod migrate;
 
-pub use init::{find_r_repositories, init};
+pub use init::{create_gitignore, find_r_repositories, init};
 pub use migrate::migrate_renv;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,5 @@
 mod init;
 mod migrate;
 
-pub use init::{create_gitignore, find_r_repositories, init};
+pub use init::{create_gitignore, create_library_structure, find_r_repositories, init};
 pub use migrate::migrate_renv;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,5 +2,5 @@ mod commands;
 mod context;
 pub mod utils;
 
-pub use commands::{create_gitignore, find_r_repositories, init, migrate_renv};
+pub use commands::{create_gitignore, create_library_structure, find_r_repositories, init, migrate_renv};
 pub use context::CliContext;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,5 +2,5 @@ mod commands;
 mod context;
 pub mod utils;
 
-pub use commands::{find_r_repositories, init, migrate_renv};
+pub use commands::{create_gitignore, find_r_repositories, init, migrate_renv};
 pub use context::CliContext;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 use fs_err::{self as fs, read_to_string, write};
 use rv::cli::utils::timeit;
-use rv::cli::{create_gitignore, find_r_repositories, init, migrate_renv, CliContext};
+use rv::cli::{create_gitignore, create_library_structure, find_r_repositories, init, migrate_renv, CliContext};
 use rv::{
     activate, add_packages, deactivate, read_and_verify_config, CacheInfo, Config, Git, Http,
     Lockfile, ProjectInfo, RCmd, RCommandLine, ResolvedDependency, Resolver, SyncHandler, Version,
@@ -342,6 +342,7 @@ fn try_main() -> Result<()> {
             let unresolved = migrate_renv(&renv_file, &cli.config_file)?;
             // migrate renv will create the config file, so parent directory is confirmed to exist
             let project_dir = &cli.config_file.parent().unwrap().to_path_buf();
+            create_library_structure(project_dir)?;
             create_gitignore(project_dir)?;
             activate(project_dir)?;
             let content = read_to_string(project_dir.join(".Rprofile"))?.replace(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
-use fs_err::{self as fs, write};
+use fs_err::{self as fs, read_to_string, write};
 use rv::cli::utils::timeit;
-use rv::cli::{find_r_repositories, init, migrate_renv, CliContext};
+use rv::cli::{create_gitignore, find_r_repositories, init, migrate_renv, CliContext};
 use rv::{
     activate, add_packages, deactivate, read_and_verify_config, CacheInfo, Config, Git, Http,
     Lockfile, ProjectInfo, RCmd, RCommandLine, ResolvedDependency, Resolver, SyncHandler, Version,
@@ -340,6 +340,15 @@ fn try_main() -> Result<()> {
             subcommand: MigrateSubcommand::Renv { renv_file },
         } => {
             let unresolved = migrate_renv(&renv_file, &cli.config_file)?;
+            // migrate renv will create the config file, so parent directory is confirmed to exist
+            let project_dir = &cli.config_file.parent().unwrap().to_path_buf();
+            create_gitignore(project_dir)?;
+            activate(project_dir)?;
+            let content = read_to_string(project_dir.join(".Rprofile"))?.replace(
+                "source(\"renv/activate.R\")",
+                "# source(\"renv/activate.R\")",
+            );
+            write(project_dir.join(".Rprofile"), content)?;
             if unresolved.is_empty() {
                 println!(
                     "{} was successfully migrated to {}",

--- a/src/renv.rs
+++ b/src/renv.rs
@@ -219,7 +219,7 @@ fn resolve_repository<'a>(
 
     // if a repository is not found in its specified repository, look in the rest of the repositories
     // sacrificing one additional iteration step of re-looking up in preferred repository for less complexity
-    if let Some((pkg, repo)) = repo_pairs
+    if let Some((found_pkg, repo)) = repo_pairs
         .into_iter()
         .find_map(|(repo, repo_db, force_source)| {
             let (pkg, _) =
@@ -227,10 +227,10 @@ fn resolve_repository<'a>(
             Some((pkg, repo))
         })
     {
-        if pkg.version == pkg_info.version {
+        if found_pkg.version == pkg_info.version {
             Ok(Source::Repository(repo))
         } else {
-            Err(format!("Package version not found in repositories. Found version {} in {}", pkg.version, repo.url).into())
+            Err(format!("Package version ({}) not found in repositories. Found version {} in {}", pkg_info.version, found_pkg.version, repo.url).into())
         }
     } else {
         Err("Package not found in repositories".into())

--- a/src/renv.rs
+++ b/src/renv.rs
@@ -230,7 +230,7 @@ fn resolve_repository<'a>(
         if pkg.version == pkg_info.version {
             Ok(Source::Repository(repo))
         } else {
-            Err("Package version not found in repositories".into())
+            Err(format!("Package version not found in repositories. Found version {} in {}", pkg.version, repo.url).into())
         }
     } else {
         Err("Package not found in repositories".into())

--- a/src/renv.rs
+++ b/src/renv.rs
@@ -219,18 +219,22 @@ fn resolve_repository<'a>(
 
     // if a repository is not found in its specified repository, look in the rest of the repositories
     // sacrificing one additional iteration step of re-looking up in preferred repository for less complexity
-    repo_pairs
+    if let Some((pkg, repo)) = repo_pairs
         .into_iter()
         .find_map(|(repo, repo_db, force_source)| {
-            repo_db.find_package(
-                &pkg_info.package,
-                Some(&version_requirement),
-                r_version,
-                *force_source,
-            )?;
-            Some(Source::Repository(repo))
+            let (pkg, _) =
+                repo_db.find_package(&pkg_info.package, None, r_version, *force_source)?;
+            Some((pkg, repo))
         })
-        .ok_or("Could not find package in repository".into())
+    {
+        if pkg.version == pkg_info.version {
+            Ok(Source::Repository(repo))
+        } else {
+            Err("Package version not found in repositories".into())
+        }
+    } else {
+        Err("Package not found in repositories".into())
+    }
 }
 
 // Expected GitHub sourced package format from renv.lock

--- a/src/snapshots/rv__renv__tests__renv_resolver.snap
+++ b/src/snapshots/rv__renv__tests__renv_resolver.snap
@@ -6,5 +6,5 @@ expression: out
 { name = "rv.git.pkgA", path = "src/tests/renv/rv.git.pkgA_0.0.0.9000.tar.gz" }
 { name = "simpar", repository = "gh-pkg-mirror" }
 --- unresolved --- 
-`R6` could not be resolved due to: "Package version not found in repositories"
+`R6` could not be resolved due to: "Package version not found in repositories. Found version 2.5.1 in https://cran-binary"
 `slurmtools` could not be resolved due to: "Package not found in repositories"

--- a/src/snapshots/rv__renv__tests__renv_resolver.snap
+++ b/src/snapshots/rv__renv__tests__renv_resolver.snap
@@ -2,9 +2,9 @@
 source: src/renv.rs
 expression: out
 ---
-{ name = "R6", repository = "cran-binary" }
 { name = "ghqc", git = "https://github.com/a2-ai/ghqc", commit = "55c23eb6a444542dab742d3d37c7b65af7b12e38" }
 { name = "rv.git.pkgA", path = "src/tests/renv/rv.git.pkgA_0.0.0.9000.tar.gz" }
 { name = "simpar", repository = "gh-pkg-mirror" }
 --- unresolved --- 
-`slurmtools` could not be resolved due to: "Could not find package in repository"
+`R6` could not be resolved due to: "Package version not found in repositories"
+`slurmtools` could not be resolved due to: "Package not found in repositories"

--- a/src/snapshots/rv__renv__tests__renv_resolver.snap
+++ b/src/snapshots/rv__renv__tests__renv_resolver.snap
@@ -6,5 +6,5 @@ expression: out
 { name = "rv.git.pkgA", path = "src/tests/renv/rv.git.pkgA_0.0.0.9000.tar.gz" }
 { name = "simpar", repository = "gh-pkg-mirror" }
 --- unresolved --- 
-`R6` could not be resolved due to: "Package version not found in repositories. Found version 2.5.1 in https://cran-binary"
+`R6` could not be resolved due to: "Package version (2.5.0) not found in repositories. Found version 2.5.1 in https://cran-binary"
 `slurmtools` could not be resolved due to: "Package not found in repositories"

--- a/src/tests/renv/renv.lock
+++ b/src/tests/renv/renv.lock
@@ -32,7 +32,7 @@
     },
     "R6": {
       "Package": "R6",
-      "Version": "2.5.1",
+      "Version": "2.5.0",
       "Source": "Repository",
       "Repository": "cran-binary",
       "Requirements": [


### PR DESCRIPTION
After running through a real renv migration with a scientist, realized a few life improvements for the users. i.e. need to init the project as an rv project instead of only creating the config file and remove the renv activation from the .Rprofile.

Also found indicating that a package could not be found in a repository vs the version was not found needs to be more clearly stated in error handling since that has direct implication on how the manual resolution occurs