### PR TITLE
canonicalize path before getting parent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn try_main() -> Result<()> {
         } => {
             let unresolved = migrate_renv(&renv_file, &cli.config_file)?;
             // migrate renv will create the config file, so parent directory is confirmed to exist
-            let project_dir = &cli.config_file.canonicalize().unwrap().parent().unwrap().to_path_buf();
+            let project_dir = &cli.config_file.canonicalize()?.parent().unwrap().to_path_buf();
             create_library_structure(project_dir)?;
             create_gitignore(project_dir)?;
             activate(project_dir)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn try_main() -> Result<()> {
         } => {
             let unresolved = migrate_renv(&renv_file, &cli.config_file)?;
             // migrate renv will create the config file, so parent directory is confirmed to exist
-            let project_dir = &cli.config_file.parent().unwrap().to_path_buf();
+            let project_dir = &cli.config_file.canonicalize().unwrap().parent().unwrap().to_path_buf();
             create_library_structure(project_dir)?;
             create_gitignore(project_dir)?;
             activate(project_dir)?;


### PR DESCRIPTION
Found error where directory could not be found in activate as part of renv migration because the parent of the default config file is "". Canonicalizing before getting parent