### PR TITLE
Linux URL strip for init

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -138,9 +138,22 @@ pub fn find_r_repositories() -> Result<Vec<Repository>, InitError> {
         .lines()
         .filter_map(|line| {
             let mut parts = line.splitn(2, '\t');
+            let alias = parts.next()?.to_string();
+            let mut url = parts.next()?.to_string();
+            let mut url_parts = url.split('/');
+            let mut new_url = Vec::new();
+            while let Some(part) = url_parts.next() {
+                if part == "__linux__" {
+                    url_parts.next(); // Skip the next path element
+                } else {
+                    new_url.push(part);
+                }
+            }
+            url = new_url.join("/");
+
             Some(Repository::new(
-                parts.next()?.to_string(),
-                parts.next()?.to_string(),
+                alias,
+                url,
                 false,
             ))
         })

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -150,6 +150,9 @@ pub fn find_r_repositories() -> Result<Vec<Repository>, InitError> {
 }
 
 fn strip_linux_url(url: &str) -> String {
+    if !url.contains("__linux__") {
+        return url.to_string();
+    }
     let mut url_parts = url.split('/');
     let mut new_url = Vec::new();
     while let Some(part) = url_parts.next() {


### PR DESCRIPTION
During `rv init` we query R's `getOption("repos")` which sometimes include the `__linux__/{arch}` for PPM and PRISM linux binaries. Since `rv` injects that option when found, it is better for cross-system compatibility to strip that from the url before printing to the Config.