### PR TITLE
List Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use crate::lockfile::Source;
 use crate::package::{deserialize_version, Version};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -15,7 +15,7 @@ struct Author {
     maintainer: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Repository {
     pub alias: String,

--- a/src/resolver/dependency.rs
+++ b/src/resolver/dependency.rs
@@ -246,6 +246,10 @@ impl<'d> ResolvedDependency<'d> {
 
         (res, deps)
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl fmt::Debug for ResolvedDependency<'_> {


### PR DESCRIPTION
Initial pass at listing dependencies and repositories. I've already felt and heard wanting a quick way to just get see what's in the config without having to open the file. We also don't currently have a way to see all of the packages that need to be in the library.

There are additional subcommands and flags to be added (like `--include-source` to add the resolved source to each dependency and `rv list library` to be our equivalent to `installed.packages`), but this fills the immediate small need/want