### PR TITLE
Init force option for config overwriting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -46,10 +46,15 @@ pub fn init(
     r_version: &str,
     repositories: &[Repository],
     dependencies: &[String],
+    force: bool,
 ) -> Result<(), InitError> {
     let proj_dir = project_directory.as_ref();
     create_library_structure(proj_dir)?;
     create_gitignore(proj_dir)?;
+    let config_path = proj_dir.join(CONFIG_FILENAME);
+    if config_path.exists() && !force {
+        return Ok(())
+    }
     let project_name = proj_dir
         .canonicalize()
         .map_err(|e| InitError {
@@ -230,6 +235,7 @@ mod tests {
             &r_version.original,
             &repositories,
             &dependencies,
+            false
         )
         .unwrap();
         let dir = &project_directory.into_path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ pub enum Command {
         no_repositories: bool,
         #[clap(long, value_parser, num_args = 1..)]
         add: Vec<String>,
+        #[clap(long)]
+        /// Force new init. This will replace content in your rproject.toml
+        force: bool
     },
     /// Returns the path for the library for the current project/system.
     /// The path is always in unix format
@@ -225,6 +228,7 @@ fn try_main() -> Result<()> {
             r_version,
             no_repositories,
             add,
+            force, 
         } => {
             let r_version = if let Some(r) = r_version {
                 // Make sure input is a valid version format. NOT checking if it is a valid R version on system in init
@@ -256,7 +260,7 @@ fn try_main() -> Result<()> {
             } else {
                 find_r_repositories().unwrap_or(Vec::new())
             };
-            init(&project_directory, &r_version, &repositories, &add)?;
+            init(&project_directory, &r_version, &repositories, &add, force)?;
             activate(&project_directory)?;
             println!(
                 "rv project successfully initialized at {}",


### PR DESCRIPTION
rv init will currently overwrite existing config files. Adding `force` option to stop overwrite by default but provide the option to the user