### PR TITLE
Remove Command + Add logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/add_remove.rs
+++ b/src/add_remove.rs
@@ -16,20 +16,27 @@ pub fn read_and_verify_config(config_file: impl AsRef<Path>) -> Result<DocumentM
     Ok(config_content.parse::<DocumentMut>().unwrap()) // Verify config was valid toml above
 }
 
-pub fn add_packages(config_doc: &mut DocumentMut, packages: Vec<String>) -> Result<(), AddError> {
+pub fn remove_packages(config_doc: &mut DocumentMut, packages: Vec<String>) {
+    let config_deps = get_mut_array(config_doc);
+    let dep_names = get_dep_names(&config_deps);
+    for p in packages {
+        // If a dependency matches the package, remove it
+        if let Some(index) = dep_names.iter().position(|dep| dep == &p) {
+            config_deps.remove(index);
+        }
+    }
+
+    // Set a trailing new line and comma for the last element for proper formatting
+    config_deps.set_trailing("\n");
+    config_deps.set_trailing_comma(true);
+}
+
+pub fn add_packages(config_doc: &mut DocumentMut, packages: Vec<String>) {
     // get the dependencies array
     let config_deps = get_mut_array(config_doc);
 
     // collect the names of all of the dependencies
-    let config_dep_names = config_deps
-        .iter()
-        .filter_map(|v| match v {
-            Value::String(s) => Some(s.value().as_str()),
-            Value::InlineTable(t) => t.get("name").and_then(|v| v.as_str()),
-            _ => None,
-        })
-        .map(|s| s.to_string()) // Need to allocate so values are not a reference to a mut
-        .collect::<Vec<_>>();
+    let config_dep_names = get_dep_names(config_deps);
 
     // Determine if the dep to add is in the config, if not add it
     for d in packages {
@@ -45,8 +52,6 @@ pub fn add_packages(config_doc: &mut DocumentMut, packages: Vec<String>) -> Resu
     // Set a trailing new line and comma for the last element for proper formatting
     config_deps.set_trailing("\n");
     config_deps.set_trailing_comma(true);
-
-    Ok(())
 }
 
 fn get_mut_array(doc: &mut DocumentMut) -> &mut Array {
@@ -65,6 +70,18 @@ fn get_mut_array(doc: &mut DocumentMut) -> &mut Array {
         last.decor_mut().set_suffix("");
     }
     deps
+}
+
+fn get_dep_names(array: &Array) -> Vec<String> {
+    array
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => Some(s.value().as_str()),
+            Value::InlineTable(t) => t.get("name").and_then(|v| v.as_str()),
+            _ => None,
+        })
+        .map(|v| v.unwrap_or_default().to_string()) // Need to allocate so values are not a reference to a mut
+        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -91,7 +108,7 @@ mod tests {
     fn add_remove() {
         let config_file = "src/tests/valid_config/all_fields.toml";
         let mut doc = read_and_verify_config(&config_file).unwrap();
-        add_packages(&mut doc, vec!["pkg1".to_string(), "pkg2".to_string()]).unwrap();
+        add_packages(&mut doc, vec!["pkg1".to_string(), "pkg2".to_string()]);
         insta::assert_snapshot!("add_remove", doc.to_string());
     }
 }

--- a/src/add_remove.rs
+++ b/src/add_remove.rs
@@ -18,11 +18,12 @@ pub fn read_and_verify_config(config_file: impl AsRef<Path>) -> Result<DocumentM
 
 pub fn remove_packages(config_doc: &mut DocumentMut, packages: Vec<String>) {
     let config_deps = get_mut_array(config_doc);
-    let dep_names = get_dep_names(&config_deps);
+    let mut dep_names = get_dep_names(&config_deps);
     for p in packages {
         // If a dependency matches the package, remove it
         if let Some(index) = dep_names.iter().position(|dep| dep == &p) {
             config_deps.remove(index);
+            dep_names.remove(index);
         }
     }
 
@@ -102,13 +103,15 @@ pub enum AddErrorKind {
 
 #[cfg(test)]
 mod tests {
-    use crate::{add_packages, read_and_verify_config};
+    use crate::{add_packages, read_and_verify_config, remove_packages};
 
     #[test]
     fn add_remove() {
         let config_file = "src/tests/valid_config/all_fields.toml";
         let mut doc = read_and_verify_config(&config_file).unwrap();
         add_packages(&mut doc, vec!["pkg1".to_string(), "pkg2".to_string()]);
-        insta::assert_snapshot!("add_remove", doc.to_string());
+        insta::assert_snapshot!("add", doc.to_string());
+        remove_packages(&mut doc, vec!["pkg1".to_string(), "pkg2".to_string()]);
+        insta::assert_snapshot!("remove", doc.to_string());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod activate;
-mod add;
+mod add_remove;
 mod cache;
 mod config;
 mod fs;
@@ -23,7 +23,7 @@ pub mod cli;
 pub mod consts;
 
 pub use activate::{activate, deactivate};
-pub use add::{add_packages, read_and_verify_config};
+pub use add_remove::{add_packages, read_and_verify_config, remove_packages};
 pub use cache::{utils::hash_string, CacheInfo, DiskCache, PackagePaths};
 pub use config::{Config, ConfigDependency, Repository};
 pub use git::{Git, GitOperations};

--- a/src/snapshots/rv__add_remove__tests__add.snap
+++ b/src/snapshots/rv__add_remove__tests__add.snap
@@ -1,0 +1,35 @@
+---
+source: src/add_remove.rs
+expression: doc.to_string()
+---
+[project]
+name = "project_name"
+# Can specify which version of R is required, could be used later in rv as R version manager?
+r_version = "4.4.1"
+description = ""
+authors = [{name = "Bob", email="hello@acme.org", maintainer = true}]
+license = "MIT"
+keywords = []
+
+# Are suggested deps also enforcing repository? Only used if you're making a library
+suggests = []
+
+# Order matters
+repositories = [
+    { alias = "cran", url = "whatever it is"},
+    { alias = "mpn", url = "https://mpn.metworx.com/snapshots/stable/2020-09-20"},
+]
+
+dependencies = [
+    "dplyr",
+    { name = "some-package", repository = "mpn", install_suggestions = true },
+    { name = "some-package", path = "../mpn", install_suggestions = true },
+    { name = "some-package", git = "https://github.com/A2-ai/scicalc", tag = "v0.1.1", install_suggestions = true },
+    { name = "some-package", git = "https://github.com/A2-ai/scicalc", commit = "bc50e550e432c3c620714f30dd59115801f89995", install_suggestions = true },
+    "pkg1",
+    "pkg2",
+]
+
+[project.urls]
+homepage = ""
+issues = ""

--- a/src/snapshots/rv__add_remove__tests__remove.snap
+++ b/src/snapshots/rv__add_remove__tests__remove.snap
@@ -1,6 +1,6 @@
 ---
-source: src/add.rs
-expression: read_to_string(&config_file).unwrap()
+source: src/add_remove.rs
+expression: doc.to_string()
 ---
 [project]
 name = "project_name"
@@ -26,8 +26,6 @@ dependencies = [
     { name = "some-package", path = "../mpn", install_suggestions = true },
     { name = "some-package", git = "https://github.com/A2-ai/scicalc", tag = "v0.1.1", install_suggestions = true },
     { name = "some-package", git = "https://github.com/A2-ai/scicalc", commit = "bc50e550e432c3c620714f30dd59115801f89995", install_suggestions = true },
-    "pkg1",
-    "pkg2",
 ]
 
 [project.urls]


### PR DESCRIPTION
During the training session this morning, there was a scenario where someone added a package that was not a part of a repository in their config. There immediate reaction was "oh that's there now? I have to remove it??". The feedback was both:
1. We'd rather not have to edit the config and just use `rv remove`
2. If the add doesn't work, why should we have to remove it in the first place?

This PR both adds the `rv remove` functionality to mirror `rv add` and changes the logic of config editing to only write after a successful sync