### PR TITLE
activate.R erroring with setNames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -64,10 +64,8 @@ pub(crate) const ACTIVATE_FILE_TEMPLATE: &str = r#"local({%global wd content%
 		rv_r_ver <- sub("r-version: (.+)", "\\1", grep("^r-version:", rv_info, value = TRUE))
 		repo_str <- sub("repositories: ", "", grep("^repositories:", rv_info, value = TRUE))
 		repo_entries <- gsub("[()]", "", strsplit(repo_str, "), (", fixed = TRUE)[[1]])
-		repo_list <- setNames(
-			trimws(sub(".*, ", "", repo_entries)),  # Extract URL
-			trimws(sub(", .*", "", repo_entries))   # Extract Name
-		)
+    repo_list <- trimws(sub(".*, ", "", repo_entries)),  # Extract URL
+    names(repo_list) <- trimws(sub(", .*", "", repo_entries))   # Extract Name
 		# this might not yet exist, so we'll normalize it but not force it to exist
 		# and we create it below as needed
 		rv_lib <- normalizePath(rv_lib, mustWork = FALSE)


### PR DESCRIPTION
Found bug in activate.R where setNames cannot be found since it is not base R (its part of `stats`). Updated to use true base R