### PR TITLE
add cache + number of workers to summary so visible to users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod repository_urls;
 mod resolver;
 mod sync;
 mod system_info;
+mod utils;
 
 #[cfg(feature = "cli")]
 pub mod cli;

--- a/src/project_summary.rs
+++ b/src/project_summary.rs
@@ -1,4 +1,3 @@
-use core::num;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -7,13 +6,13 @@ use std::{
 
 use serde::Serialize;
 
+use crate::utils::get_max_workers;
 use crate::{
     cache::InstallationStatus,
-    consts::NUM_CPUS_ENV_VAR_NAME,
     lockfile::Source,
     package::{Operator, PackageType},
-    DiskCache, Library, Lockfile, Repository, RepositoryDatabase, ResolvedDependency, SystemInfo,
-    Version, VersionRequirement,
+    DiskCache, Library, Lockfile, Repository, RepositoryDatabase, ResolvedDependency,
+    SystemInfo, Version, VersionRequirement,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -37,10 +36,6 @@ impl<'a> ProjectSummary<'a> {
         cache: &'a DiskCache,
         lockfile: Option<&'a Lockfile>,
     ) -> Self {
-        let max_workers = std::env::var(NUM_CPUS_ENV_VAR_NAME)
-            .ok()
-            .and_then(|x| x.parse::<usize>().ok())
-            .unwrap_or_else(num_cpus::get);
         Self {
             r_version,
             system_info: &cache.system_info,
@@ -55,7 +50,7 @@ impl<'a> ProjectSummary<'a> {
             ),
             cache_root: &cache.root,
             remote_info: RemoteInfo::new(repositories, repo_dbs, &r_version.major_minor()),
-            max_workers,
+            max_workers: get_max_workers(),
         }
     }
 }

--- a/src/project_summary.rs
+++ b/src/project_summary.rs
@@ -1,3 +1,4 @@
+use core::num;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -7,7 +8,12 @@ use std::{
 use serde::Serialize;
 
 use crate::{
-    cache::InstallationStatus, consts::NUM_CPUS_ENV_VAR_NAME, lockfile::Source, package::{Operator, PackageType}, DiskCache, Library, Lockfile, Repository, RepositoryDatabase, ResolvedDependency, SystemInfo, Version, VersionRequirement
+    cache::InstallationStatus,
+    consts::NUM_CPUS_ENV_VAR_NAME,
+    lockfile::Source,
+    package::{Operator, PackageType},
+    DiskCache, Library, Lockfile, Repository, RepositoryDatabase, ResolvedDependency, SystemInfo,
+    Version, VersionRequirement,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -15,7 +21,7 @@ pub struct ProjectSummary<'a> {
     r_version: &'a Version,
     system_info: &'a SystemInfo,
     dependency_info: DependencyInfo<'a>,
-    cache_root: &'a PathBuf, 
+    cache_root: &'a PathBuf,
     remote_info: RemoteInfo<'a>,
     max_workers: usize,
 }
@@ -32,9 +38,9 @@ impl<'a> ProjectSummary<'a> {
         lockfile: Option<&'a Lockfile>,
     ) -> Self {
         let max_workers = std::env::var(NUM_CPUS_ENV_VAR_NAME)
-        .ok()
-        .and_then(|x| x.parse::<usize>().ok())
-        .unwrap_or_else(num_cpus::get);
+            .ok()
+            .and_then(|x| x.parse::<usize>().ok())
+            .unwrap_or_else(num_cpus::get);
         Self {
             r_version,
             system_info: &cache.system_info,
@@ -58,7 +64,7 @@ impl fmt::Display for ProjectSummary<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "OS: {}{}\nR Version: {}\n\nSync Parallelization: {} workers\nCache Location: {}\n\n",
+            "== System Information == \nOS: {}{}\nR Version: {}\n\nNum Workers for Sync: {} ({} cpus available)\nCache Location: {}\n\n",
             self.system_info.os_family(),
             if let Some(arch) = self.system_info.arch() {
                 format!(" ({arch})")
@@ -67,6 +73,7 @@ impl fmt::Display for ProjectSummary<'_> {
             },
             self.r_version,
             self.max_workers,
+            num_cpus::get(),
             self.cache_root.as_path().to_string_lossy(),
         )?;
 

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -7,12 +7,12 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::consts::NUM_CPUS_ENV_VAR_NAME;
 use crate::lockfile::Source;
 use crate::package::PackageType;
 use crate::sync::changes::SyncChange;
 use crate::sync::errors::{SyncError, SyncErrorKind, SyncErrors};
 use crate::sync::{sources, LinkMode};
+use crate::utils::get_max_workers;
 use crate::{BuildPlan, BuildStep, DiskCache, GitExecutor, Library, RCmd, ResolvedDependency};
 
 #[derive(Debug)]
@@ -34,10 +34,6 @@ impl<'a> SyncHandler<'a> {
         cache: &'a DiskCache,
         staging_path: impl AsRef<Path>,
     ) -> Self {
-        let max_workers = std::env::var(NUM_CPUS_ENV_VAR_NAME)
-            .ok()
-            .and_then(|x| x.parse::<usize>().ok())
-            .unwrap_or_else(num_cpus::get);
         Self {
             project_dir,
             library,
@@ -46,7 +42,7 @@ impl<'a> SyncHandler<'a> {
             dry_run: false,
             show_progress_bar: false,
             has_lockfile: false,
-            max_workers,
+            max_workers: get_max_workers(),
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use crate::consts::NUM_CPUS_ENV_VAR_NAME;
+
+pub(crate) fn get_max_workers() -> usize {
+    std::env::var(NUM_CPUS_ENV_VAR_NAME)
+        .ok()
+        .and_then(|x| x.parse::<usize>().ok())
+        .unwrap_or_else(num_cpus::get)
+}


### PR DESCRIPTION
this PR adds some additional details that are helpful for scanning, particularly when customizing rv behavior. In times when needing to adjust the cache location or core count, want a sanity check it registers, particularly if switching between shell sessions or coming back to an existing session.

I'm not sure if "sync parallelization" is the right term, but i struggled to think of anyhthing better