### PR TITLE
`--r-version` for summary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,10 @@ pub enum Command {
     Summary {
         #[clap(short, long)]
         json: bool,
+        /// Specify a R version different from the one in the config.
+        /// The command will not error even if this R version is not found
+        #[clap(long)]
+        r_version: Option<Version>,
     },
     /// Simple information about the project
     Info {
@@ -492,8 +496,8 @@ fn try_main() -> Result<()> {
                 }
             }
         }
-        Command::Summary { json } => {
-            let mut context = CliContext::new(&cli.config_file, None)?;
+        Command::Summary { json , r_version} => {
+            let mut context = CliContext::new(&cli.config_file, r_version)?;
             context.load_databases()?;
             let resolved = resolve_dependencies(&context, &ResolveMode::Default);
             let summary = ProjectSummary::new(


### PR DESCRIPTION
Similar to the use cases for `rv plan --r-version 4.3`, it is nice to specify the R version in `summary` to see available package counts