### PR TITLE
R path

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -864,7 +864,7 @@ dependencies = [
         execute_repository_action(&config_path, action).unwrap();
 
         // Now try with a different existing alias - this should fail
-        let action = RepositoryAction::Update {
+        let _action = RepositoryAction::Update {
             matcher: RepositoryMatcher::ByAlias("posit".to_string()),
             updates: RepositoryUpdates {
                 alias: Some("posit".to_string()), // Wait, we need another repo first

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -704,7 +704,7 @@ mod tests {
     use serde::Deserialize;
     use tempfile::TempDir;
 
-    use crate::config::Config;
+    use crate::config::{Config, RVersion};
     use crate::consts::{BASE_PACKAGES, DESCRIPTION_FILENAME};
     use crate::http::HttpError;
     use crate::package::{Package, parse_package_file};
@@ -773,7 +773,10 @@ mod tests {
         let content = std::fs::read_to_string(path).unwrap();
         let parts: Vec<_> = content.splitn(3, "---").collect();
         let config = Config::from_str(parts[0]).expect("valid config");
-        let r_version = config.r_version().clone();
+        let r_version = match config.r_version() {
+            RVersion::Strict(v) => v.clone(),
+            _ => unreachable!("Configs have strict R version specified")
+        };
         let repositories = if let Ok(data) = toml::from_str::<TestRepositories>(parts[1]) {
             let mut res = Vec::new();
             for r in data.repos {


### PR DESCRIPTION
For build processes, it is often helpful to not have to specify an R version, instead just use the version found on the path. Additionally, R installed in non-standard locations has previously not been accessible to `rv` (except if it is added to the PATH). To address both of these issues is the addition of the `r_path` field, which if specified `rv` will look for R at that location (and that location only). This allows the `r_version` to be optional, while still requiring specificity around what R is to be used. 

The rules for the two fields are as followed:
1. If r_path and r_version is specified, the version found at r_path MUST hazy match the one specified in r_version
2. If r_path is specified, but r_version is not, the version found at r_path will be the version of r used
3. If r_version is specified, but r_path is not, we will attempt to find that R version on the system
4. If neither are specified, fail