### PR TITLE
Repository URL using Url

### DIFF
--- a/example_projects/trailing-slash/rproject.toml
+++ b/example_projects/trailing-slash/rproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "trailing-slash"
+r_version = "4.4"
+description = "URL's that ended with a slash should not rely on servers to properly parse (i.e. PRISM does not)"
+
+repositories = [
+    { alias = "stratus", url = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-09/" },
+]
+
+dependencies = [
+    "R6"
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,10 @@ impl<'de> Deserialize<'de> for HttpUrl {
     {
         let s = String::deserialize(deserializer)?;
         if s.starts_with("http://") || s.starts_with("https://") {
-            if let Ok(url) = Url::parse(&s) {
+            if let Ok(mut url) = Url::parse(&s) {
+                // Remove trailing slashes from the path
+                let path = url.path().trim_end_matches('/').to_string();
+                url.set_path(&path);
                 return Ok(Self(url));
             }
         }
@@ -74,7 +77,7 @@ impl Repository {
 pub enum ConfigDependency {
     Simple(String),
     Git {
-        // It can be http or git
+        // It can be http or ssh
         git: GitUrl,
         commit: Option<String>,
         tag: Option<String>,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -130,18 +130,6 @@ impl Source {
         matches!(self, Source::Builtin { .. })
     }
 
-    /// The key to use in the cache: URL for a package repository, git URL for a git repository
-    /// and for local the actual path
-    pub fn source_path(&self) -> &str {
-        match self {
-            Source::Repository { repository } => repository.as_str(),
-            Source::Local { path, .. } => path.to_str().unwrap(),
-            Source::Git { git, .. } | Source::RUniverse { git, .. } => git.url(),
-            Source::Url { url, .. } => url.as_str(),
-            Source::Builtin { .. } => "",
-        }
-    }
-
     pub fn sha(&self) -> &str {
         match self {
             Source::Git { sha, .. } | Source::RUniverse { sha, .. } => sha.as_str(),

--- a/src/repository_urls.rs
+++ b/src/repository_urls.rs
@@ -114,9 +114,10 @@ fn get_binary_path(
 
 fn get_windows_url(url: &Url, file_path: &[&str], r_version: &[u32; 2]) -> Url {
     let mut new_url = url.clone();
-    let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
-    segments.extend(["bin", "windows", "contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
-    drop(segments);
+    {
+        let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
+        segments.extend(["bin", "windows", "contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
+    }
     new_url
 }
 
@@ -138,21 +139,21 @@ fn get_mac_url(
     let arch = sysinfo.arch()?;
 
     let mut new_url = url.clone();
-    let mut segments = new_url.path_segments_mut().ok()?;
-    segments.extend(["bin", "macosx"].iter());
+
+    {
+        let mut segments = new_url.path_segments_mut().ok()?;
+        segments.extend(["bin", "macosx"].iter());
 
 
-    // The additional path element containing the arch is officially introduced for R > 4.3.
-    // Some sources (PPM for example) start to include arch earlier for arm64.
-    // Therefore, we only do not include the additional path element for x86_64 with R <= 4.2
-    if !(arch == "x86_64" && r_version <= &[4, 2]) {
-        segments.push(&format!("big-sur-{arch}"));
+        // The additional path element containing the arch is officially introduced for R > 4.3.
+        // Some sources (PPM for example) start to include arch earlier for arm64.
+        // Therefore, we only do not include the additional path element for x86_64 with R <= 4.2
+        if !(arch == "x86_64" && r_version <= &[4, 2]) {
+            segments.push(&format!("big-sur-{arch}"));
+        }
+
+        segments.extend(["contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
     }
-
-    segments.extend(["contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
-
-    // need to drop segments to end mutable borrow in order to properly return new_url
-    drop(segments);
 
     Some(new_url)
 }

--- a/src/repository_urls.rs
+++ b/src/repository_urls.rs
@@ -1,4 +1,7 @@
+use std::error::Error;
+
 use crate::consts::PACKAGE_FILENAME;
+use crate::lockfile::Source;
 use crate::{OsType, ResolvedDependency, SystemInfo};
 use url::Url;
 
@@ -76,11 +79,11 @@ fn get_distro_name(sysinfo: &SystemInfo, distro: &str) -> Option<String> {
 ///
 /// Thus the full path segment is `__linux__/<distribution codename>/<snapshot date>/src/contrib/<file name>?r_version=<R version major>.<R version minor>&arch=<system arch>`
 fn get_binary_path(
-    url: &str,
+    url: &Url,
     file_path: &str,
     r_version: &[u32; 2],
     sysinfo: &SystemInfo,
-) -> Option<String> {
+) -> Option<Url> {
     // rv does not support binaries for less than R/3.6
     if r_version < &[3, 6] {
         return None;
@@ -95,13 +98,13 @@ fn get_binary_path(
 }
 
 fn get_binary_tarball_path(
-    url: &str,
+    url: &Url,
     name: &str,
     version: &str,
     path: Option<&str>,
     r_version: &[u32; 2],
     sysinfo: &SystemInfo,
-) -> Option<String> {
+) -> Option<Url> {
     let path = path.map(|x| format!("{x}/")).unwrap_or_default();
     let ext = sysinfo.os_type.tarball_extension();
     let file_path = format!("{path}{name}_{version}.{ext}");
@@ -109,26 +112,33 @@ fn get_binary_tarball_path(
     get_binary_path(url, &file_path, r_version, sysinfo)
 }
 
-fn get_source_path(url: &str, file_path: &str) -> String {
+fn get_source_path(url: &Url, file_path: &str) -> Url {
     // even if __linux__ is contained within the url, source content will be returned because no query string for PPM and PRISM
-    format!("{url}/src/contrib/{file_path}")
+    let mut new_url = url.clone();
+    let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
+    segments.extend(["src", "contrib", file_path]);
+    drop(segments);
+    new_url
 }
 
-fn get_source_tarball_path(url: &str, name: &str, version: &str, path: Option<&str>) -> String {
+fn get_source_tarball_path(url: &Url, name: &str, version: &str, path: Option<&str>) -> Url {
     let path = path.map(|x| format!("{x}/")).unwrap_or_default();
     let file_path = format!("{path}{name}_{version}.tar.gz");
     get_source_path(url, &file_path)
 }
 
 // Archived packages under the format <base url>/src/contrib/Archive/<pkg name>/<pkg name>_<pkg version>.tar.gz
-fn get_archive_tarball_path(url: &str, name: &str, version: &str) -> String {
+fn get_archive_tarball_path(url: &Url, name: &str, version: &str) -> Url {
     let file_path = format!("Archive/{name}/{name}_{version}.tar.gz");
     get_source_path(url, &file_path)
 }
 
-fn get_windows_url(url: &str, file_path: &str, r_version: &[u32; 2]) -> String {
-    let [r_major, r_minor] = r_version;
-    format!("{url}/bin/windows/contrib/{r_major}.{r_minor}/{file_path}")
+fn get_windows_url(url: &Url, file_path: &str, r_version: &[u32; 2]) -> Url {
+    let mut new_url = url.clone();
+    let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
+    segments.extend(["bin", "windows", "contrib", &format!("{}.{}", r_version[0], r_version[1]), file_path]);
+    drop(segments);
+    new_url
 }
 
 /// CRAN-type repositories have had to adapt to the introduction of the Mac arm64 processors
@@ -140,66 +150,74 @@ fn get_windows_url(url: &str, file_path: &str, r_version: &[u32; 2]) -> String {
 /// The path to the binaries built for arm64 binaries is `/bin/macosx/big-sur-arm64/contrib/4.<R minor version>`
 /// While CRAN itself only started supporting arm64 binaries at R/4.2, many repositories (including PPM) support binaries for older versions
 fn get_mac_url(
-    url: &str,
+    url: &Url,
     file_path: &str,
     r_version: &[u32; 2],
     sysinfo: &SystemInfo,
-) -> Option<String> {
+) -> Option<Url> {
     // If the system architecture cannot be determined, Mac binaries are not supported
     let arch = sysinfo.arch()?;
-    let [r_major, r_minor] = r_version;
 
-    // If the processor is arm64, binaries will only be found on this path
-    // CRAN does not officially support arm64 binaries until R/4.2, but other repositories may (i.e. PPM does)
-    if arch == "arm64" {
-        return Some(format!(
-            "{url}/bin/macosx/big-sur-{arch}/contrib/{r_major}.{r_minor}/{file_path}",
-        ));
+    let mut new_url = url.clone();
+    let mut segments = new_url.path_segments_mut().ok()?;
+    segments.extend(["bin", "macosx"].iter());
+
+
+    // The additional path element containing the arch is officially introduced for R > 4.3.
+    // Some sources (PPM for example) start to include arch earlier for arm64.
+    // Therefore, we only do not include the additional path element for x86_64 with R <= 4.2
+    if !(arch == "x86_64" && r_version <= &[4, 2]) {
+        segments.push(&format!("big-sur-{arch}"));
     }
 
-    // For x86_64, the path in which binaries are found switches after R/4.2
-    if r_version <= &[4, 2] {
-        return Some(format!(
-            "{url}/bin/macosx/contrib/{r_major}.{r_minor}/{file_path}",
-        ));
-    }
+    segments.extend(["contrib", &format!("{}.{}", r_version[0], r_version[1]), file_path]);
 
-    Some(format!(
-        "{url}/bin/macosx/big-sur-{arch}/contrib/{r_major}.{r_minor}/{file_path}",
-    ))
+    // need to drop segments to end mutable borrow in order to properly return new_url
+    drop(segments);
+
+    Some(new_url)
 }
 
 fn get_linux_url(
-    url: &str,
+    url: &Url,
     file_path: &str,
     r_version: &[u32; 2],
     sysinfo: &SystemInfo,
     distro: &str,
-) -> Option<String> {
+) -> Option<Url> {
     let [r_major, r_minor] = r_version;
-    let arch_query = sysinfo
-        .arch()
-        .map(|arch| format!("&arch={arch}"))
-        .unwrap_or_default();
+    let mut new_url = url.clone();
 
-    // if the url already contains __linux__, then we assume the user supplied the distro name purposefully
-    if url.contains("__linux__") {
-        return Some(format!(
-            "{url}/src/contrib/{file_path}?r_version={r_major}.{r_minor}{arch_query}"
-        ));
+    let insert_query_strings = |url_mut: &mut Url| {
+        let mut pairs = url_mut.query_pairs_mut();
+        pairs.append_pair("r_version", &format!("{r_major}.{r_minor}"));
+        if let Some(arch) = sysinfo.arch() {
+            pairs.append_pair("arch", arch);
+        }
+    };
+
+    let path_segs = url.path_segments()?.collect::<Vec<_>>();
+    if path_segs.iter().any(|s| *s == "__linux__") {
+        new_url.path_segments_mut().ok()?.extend(&["src", "contrib", file_path]);
+        insert_query_strings(&mut new_url);
+        return Some(new_url)
     }
-    let mut parts = url.split('/').collect::<Vec<_>>();
-    // split on `/`` will split "https://..." as 3 parts. Want to ensure there is at least one more path element at end of url
-    if parts.len() < 4 {
-        return None;
-    }
-    let edition = parts.pop()?;
-    let base_url = parts.join("/");
+
     let distro_name = get_distro_name(sysinfo, distro)?;
+    let mut segments = url.path_segments()?.collect::<Vec<_>>();
 
-    Some(format!(
-        "{base_url}/__linux__/{distro_name}/{edition}/src/contrib/{file_path}?r_version={r_major}.{r_minor}{arch_query}"
-    ))
+    // if there is not at least one path segment, we cannot determine the linux binary url
+    let edition = segments.pop()?;
+    segments.push("__linux__");
+    segments.push(&distro_name);
+    segments.push(edition);
+
+    new_url.path_segments_mut().ok()?.clear().extend(segments.into_iter().chain(["src", "contrib", file_path]));
+
+    insert_query_strings(&mut new_url);
+
+
+    Some(new_url)
 }
 
 pub struct TarballUrls {
@@ -212,17 +230,18 @@ pub fn get_tarball_urls(
     dep: &ResolvedDependency,
     r_version: &[u32; 2],
     sysinfo: &SystemInfo,
-) -> TarballUrls {
-    let url = dep.source.source_path();
-    let name = &dep.name;
-    let version = &dep.version.original;
-    let path = dep.path.as_deref();
-
-    TarballUrls {
-        source: Url::parse(&get_source_tarball_path(url, name, version, path)).expect("valid URL"),
-        binary: get_binary_tarball_path(url, name, version, path, r_version, sysinfo)
-            .map(|u| Url::parse(&u).unwrap()),
-        archive: Url::parse(&get_archive_tarball_path(url, name, version)).expect("valid URL"),
+) -> Result<TarballUrls, Box<dyn Error>> {
+    if let Source::Repository { repository } = &dep.source {
+        let name = &dep.name;
+        let version = &dep.version.original;
+        let path = dep.path.as_deref();
+        Ok(TarballUrls { 
+            source: get_source_tarball_path(repository, name, version, path), 
+            binary: get_binary_tarball_path(repository, name, version, path, r_version, sysinfo), 
+            archive: get_archive_tarball_path(repository, name, version),
+        })
+    } else {
+        Err("Dependency does not have source Repository".into())
     }
 }
 
@@ -234,23 +253,24 @@ pub fn get_package_file_urls(
     sysinfo: &SystemInfo,
 ) -> (Url, Option<Url>) {
     (
-        Url::parse(&get_source_path(url.as_str(), PACKAGE_FILENAME)).expect("valid URL"),
-        get_binary_path(url.as_str(), PACKAGE_FILENAME, r_version, sysinfo)
-            .map(|u| Url::parse(&u).unwrap()),
+        get_source_path(url, PACKAGE_FILENAME),
+        get_binary_path(url, PACKAGE_FILENAME, r_version, sysinfo)
     )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use super::*;
-    static PPM_URL: &str = "https://packagemanager.posit.co/cran/latest";
+    static PPM_URL: LazyLock<Url> = LazyLock::new(|| Url::parse("https://packagemanager.posit.co/cran/latest").unwrap());
     static TEST_FILE_NAME: &str = "test-file";
 
     #[test]
     fn test_source_url() {
-        let source_url = get_source_path(PPM_URL, TEST_FILE_NAME);
-        let ref_url = format!("{}/src/contrib/{}", PPM_URL, TEST_FILE_NAME);
-        assert_eq!(source_url, ref_url);
+        let source_url = get_source_path(&PPM_URL, TEST_FILE_NAME);
+        let ref_url = format!("{}/src/contrib/{}", &PPM_URL.as_str(), TEST_FILE_NAME);
+        assert_eq!(source_url.as_str(), ref_url);
     }
     #[test]
     fn test_binary_35_url() {
@@ -261,7 +281,7 @@ mod tests {
             "22.04",
         );
         assert_eq!(
-            get_binary_path(PPM_URL, TEST_FILE_NAME, &[3, 5], &sysinfo),
+            get_binary_path(&PPM_URL, TEST_FILE_NAME, &[3, 5], &sysinfo),
             None
         );
     }
@@ -269,49 +289,49 @@ mod tests {
     #[test]
     fn test_windows_url() {
         let sysinfo = SystemInfo::new(OsType::Windows, Some("x86_64".to_string()), None, "");
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo);
-        let ref_url = format!("{}/bin/windows/contrib/4.4/{}", PPM_URL, TEST_FILE_NAME);
-        assert_eq!(source_url, Some(ref_url))
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
+        let ref_url = format!("{}/bin/windows/contrib/4.4/{}", PPM_URL.as_str(), TEST_FILE_NAME);
+        assert_eq!(source_url.as_str(), ref_url)
     }
 
     #[test]
     fn test_mac_x86_64_r41_url() {
         let sysinfo = SystemInfo::new(OsType::MacOs, Some("x86_64".to_string()), None, "");
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 1], &sysinfo);
-        let ref_url = format!("{}/bin/macosx/contrib/4.1/{}", PPM_URL, TEST_FILE_NAME);
-        assert_eq!(source_url, Some(ref_url));
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 1], &sysinfo).unwrap();
+        let ref_url = format!("{}/bin/macosx/contrib/4.1/{}", PPM_URL.as_str(), TEST_FILE_NAME);
+        assert_eq!(source_url.as_str(), ref_url);
     }
     #[test]
     fn test_mac_arm64_r41_url() {
         let sysinfo = SystemInfo::new(OsType::MacOs, Some("arm64".to_string()), None, "");
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 1], &sysinfo);
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 1], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-arm64/contrib/4.1/{}",
-            PPM_URL, TEST_FILE_NAME
+            PPM_URL.as_str(), TEST_FILE_NAME
         );
-        assert_eq!(source_url, Some(ref_url));
+        assert_eq!(source_url.as_str(), ref_url);
     }
 
     #[test]
     fn test_mac_x86_64_r44_url() {
         let sysinfo = SystemInfo::new(OsType::MacOs, Some("x86_64".to_string()), None, "");
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo);
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-x86_64/contrib/4.4/{}",
-            PPM_URL, TEST_FILE_NAME,
+            PPM_URL.as_str(), TEST_FILE_NAME,
         );
-        assert_eq!(source_url, Some(ref_url));
+        assert_eq!(source_url.as_str(), ref_url);
     }
 
     #[test]
     fn test_mac_arm64_r44_url() {
         let sysinfo = SystemInfo::new(OsType::MacOs, Some("arm64".to_string()), None, "");
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo);
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-arm64/contrib/4.4/{}",
-            PPM_URL, TEST_FILE_NAME
+            PPM_URL.as_str(), TEST_FILE_NAME
         );
-        assert_eq!(source_url, Some(ref_url));
+        assert_eq!(source_url.as_str(), ref_url);
     }
 
     #[test]
@@ -322,25 +342,8 @@ mod tests {
             Some("jammy".to_string()),
             "22.04",
         );
-        let source_url = get_binary_path(PPM_URL, TEST_FILE_NAME, &[4, 2], &sysinfo);
+        let source_url = get_binary_path(&PPM_URL, TEST_FILE_NAME, &[4, 2], &sysinfo).unwrap();
         let ref_url = "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/test-file?r_version=4.2&arch=x86_64".to_string();
-        assert_eq!(source_url, Some(ref_url))
-    }
-
-    #[test]
-    fn test_linux_cran_url() {
-        let sysinfo = SystemInfo::new(
-            OsType::Linux("ubuntu"),
-            Some("x86_64".to_string()),
-            Some("jammy".to_string()),
-            "22.04",
-        );
-        let source_url = get_binary_path(
-            "https://cran.rstudio.com",
-            TEST_FILE_NAME,
-            &[4, 4],
-            &sysinfo,
-        );
-        assert_eq!(source_url, None);
+        assert_eq!(source_url.as_str(), ref_url)
     }
 }

--- a/src/repository_urls.rs
+++ b/src/repository_urls.rs
@@ -116,7 +116,16 @@ fn get_windows_url(url: &Url, file_path: &[&str], r_version: &[u32; 2]) -> Url {
     let mut new_url = url.clone();
     {
         let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
-        segments.extend(["bin", "windows", "contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
+        segments.extend(
+            [
+                "bin",
+                "windows",
+                "contrib",
+                &format!("{}.{}", r_version[0], r_version[1]),
+            ]
+            .iter()
+            .chain(file_path),
+        );
     }
     new_url
 }
@@ -144,7 +153,6 @@ fn get_mac_url(
         let mut segments = new_url.path_segments_mut().ok()?;
         segments.extend(["bin", "macosx"].iter());
 
-
         // The additional path element containing the arch is officially introduced for R > 4.3.
         // Some sources (PPM for example) start to include arch earlier for arm64.
         // Therefore, we only do not include the additional path element for x86_64 with R <= 4.2
@@ -152,7 +160,11 @@ fn get_mac_url(
             segments.push(&format!("big-sur-{arch}"));
         }
 
-        segments.extend(["contrib", &format!("{}.{}", r_version[0], r_version[1])].iter().chain(file_path));
+        segments.extend(
+            ["contrib", &format!("{}.{}", r_version[0], r_version[1])]
+                .iter()
+                .chain(file_path),
+        );
     }
 
     Some(new_url)
@@ -181,7 +193,7 @@ fn get_linux_url(
         let segments = ["src", "contrib"].iter().chain(file_path);
         new_url.path_segments_mut().ok()?.extend(segments);
         insert_query_strings(&mut new_url);
-        return Some(new_url)
+        return Some(new_url);
     }
 
     let distro_name = get_distro_name(sysinfo, distro)?;
@@ -195,11 +207,9 @@ fn get_linux_url(
     segments.extend(["src", "contrib"]);
     segments.extend(file_path);
 
-
     new_url.path_segments_mut().ok()?.clear().extend(segments);
 
     insert_query_strings(&mut new_url);
-
 
     Some(new_url)
 }
@@ -222,23 +232,20 @@ pub fn get_tarball_urls(
         let ext = sysinfo.os_type.tarball_extension();
 
         let file_path = path
-            .map(|p| p.split('/')
-                .into_iter()
-                .collect::<Vec<_>>()
-            )
+            .map(|p| p.split('/').into_iter().collect::<Vec<_>>())
             .unwrap_or_default();
 
-            let mut binary_file_path = file_path.clone();
-            let binary_name = format!("{name}_{version}.{ext}");
-            binary_file_path.push(&binary_name);
+        let mut binary_file_path = file_path.clone();
+        let binary_name = format!("{name}_{version}.{ext}");
+        binary_file_path.push(&binary_name);
 
-            let mut source_file_path = file_path.clone();
-            let source_name = format!("{name}_{version}.tar.gz");
-            source_file_path.push(&source_name);
+        let mut source_file_path = file_path.clone();
+        let source_name = format!("{name}_{version}.tar.gz");
+        source_file_path.push(&source_name);
 
-        Ok(TarballUrls { 
-            source: get_source_path(repository, &source_file_path), 
-            binary: get_binary_path(repository, &binary_file_path, r_version, sysinfo), 
+        Ok(TarballUrls {
+            source: get_source_path(repository, &source_file_path),
+            binary: get_binary_path(repository, &binary_file_path, r_version, sysinfo),
             archive: get_archive_tarball_path(repository, name, version),
         })
     } else {
@@ -255,7 +262,7 @@ pub fn get_package_file_urls(
 ) -> (Url, Option<Url>) {
     (
         get_source_path(url, &[PACKAGE_FILENAME]),
-        get_binary_path(url, &[PACKAGE_FILENAME], r_version, sysinfo)
+        get_binary_path(url, &[PACKAGE_FILENAME], r_version, sysinfo),
     )
 }
 
@@ -264,7 +271,8 @@ mod tests {
     use std::sync::LazyLock;
 
     use super::*;
-    static PPM_URL: LazyLock<Url> = LazyLock::new(|| Url::parse("https://packagemanager.posit.co/cran/latest").unwrap());
+    static PPM_URL: LazyLock<Url> =
+        LazyLock::new(|| Url::parse("https://packagemanager.posit.co/cran/latest").unwrap());
     static TEST_FILE_NAME: [&str; 1] = ["test-file"];
 
     #[test]
@@ -291,7 +299,11 @@ mod tests {
     fn test_windows_url() {
         let sysinfo = SystemInfo::new(OsType::Windows, Some("x86_64".to_string()), None, "");
         let source_url = get_binary_path(&PPM_URL, &TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
-        let ref_url = format!("{}/bin/windows/contrib/4.4/{}", PPM_URL.as_str(), TEST_FILE_NAME[0]);
+        let ref_url = format!(
+            "{}/bin/windows/contrib/4.4/{}",
+            PPM_URL.as_str(),
+            TEST_FILE_NAME[0]
+        );
         assert_eq!(source_url.as_str(), ref_url)
     }
 
@@ -299,7 +311,11 @@ mod tests {
     fn test_mac_x86_64_r41_url() {
         let sysinfo = SystemInfo::new(OsType::MacOs, Some("x86_64".to_string()), None, "");
         let source_url = get_binary_path(&PPM_URL, &TEST_FILE_NAME, &[4, 1], &sysinfo).unwrap();
-        let ref_url = format!("{}/bin/macosx/contrib/4.1/{}", PPM_URL.as_str(), TEST_FILE_NAME[0]);
+        let ref_url = format!(
+            "{}/bin/macosx/contrib/4.1/{}",
+            PPM_URL.as_str(),
+            TEST_FILE_NAME[0]
+        );
         assert_eq!(source_url.as_str(), ref_url);
     }
     #[test]
@@ -308,7 +324,8 @@ mod tests {
         let source_url = get_binary_path(&PPM_URL, &TEST_FILE_NAME, &[4, 1], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-arm64/contrib/4.1/{}",
-            PPM_URL.as_str(), TEST_FILE_NAME[0]
+            PPM_URL.as_str(),
+            TEST_FILE_NAME[0]
         );
         assert_eq!(source_url.as_str(), ref_url);
     }
@@ -319,7 +336,8 @@ mod tests {
         let source_url = get_binary_path(&PPM_URL, &TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-x86_64/contrib/4.4/{}",
-            PPM_URL.as_str(), TEST_FILE_NAME[0],
+            PPM_URL.as_str(),
+            TEST_FILE_NAME[0],
         );
         assert_eq!(source_url.as_str(), ref_url);
     }
@@ -330,7 +348,8 @@ mod tests {
         let source_url = get_binary_path(&PPM_URL, &TEST_FILE_NAME, &[4, 4], &sysinfo).unwrap();
         let ref_url = format!(
             "{}/bin/macosx/big-sur-arm64/contrib/4.4/{}",
-            PPM_URL.as_str(), TEST_FILE_NAME[0]
+            PPM_URL.as_str(),
+            TEST_FILE_NAME[0]
         );
         assert_eq!(source_url.as_str(), ref_url);
     }
@@ -352,7 +371,10 @@ mod tests {
     // also test the additional path elements being handled properly
     fn test_archive_url() {
         let source_url = get_archive_tarball_path(&PPM_URL, "name", "version");
-        let ref_url = format!("{}/src/contrib/Archive/name/name_version.tar.gz", PPM_URL.as_str());
+        let ref_url = format!(
+            "{}/src/contrib/Archive/name/name_version.tar.gz",
+            PPM_URL.as_str()
+        );
         assert_eq!(source_url.as_str(), ref_url);
     }
 }

--- a/src/repository_urls.rs
+++ b/src/repository_urls.rs
@@ -55,9 +55,10 @@ fn get_distro_name(sysinfo: &SystemInfo, distro: &str) -> Option<String> {
 fn get_source_path(url: &Url, file_path: &[&str]) -> Url {
     // even if __linux__ is contained within the url, source content will be returned because no query string for PPM and PRISM
     let mut new_url = url.clone();
-    let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
-    segments.extend(["src", "contrib"].iter().chain(file_path));
-    drop(segments);
+    {
+        let mut segments = new_url.path_segments_mut().expect("Valid absolute url");
+        segments.extend(["src", "contrib"].iter().chain(file_path));
+    }
     new_url
 }
 

--- a/src/sync/sources/repositories.rs
+++ b/src/sync/sources/repositories.rs
@@ -43,7 +43,8 @@ pub(crate) fn install_package(
                 pkg.version.original
             );
 
-            let tarball_url = get_tarball_urls(pkg, &cache.r_version, &cache.system_info).expect("Dependency has source Repository");
+            let tarball_url = get_tarball_urls(pkg, &cache.r_version, &cache.system_info)
+                .expect("Dependency has source Repository");
             let http = Http {};
 
             let download_and_install_source_or_archive = || -> Result<(), SyncError> {

--- a/src/sync/sources/repositories.rs
+++ b/src/sync/sources/repositories.rs
@@ -43,7 +43,7 @@ pub(crate) fn install_package(
                 pkg.version.original
             );
 
-            let tarball_url = get_tarball_urls(pkg, &cache.r_version, &cache.system_info);
+            let tarball_url = get_tarball_urls(pkg, &cache.r_version, &cache.system_info).expect("Dependency has source Repository");
             let http = Http {};
 
             let download_and_install_source_or_archive = || -> Result<(), SyncError> {


### PR DESCRIPTION
Jenna found an issue that when using a trailing slash on the repository url in PRISM, we get an error because the URL becomes `{url}//src/contrib/PACKAGES`. There is an opportunity for PRISM's server to handle this better as well, but `rv` should not rely on the server to smooth our errors (i.e. `PPM` does not error). 

Also took the opportunity to convert the `repository_url` module to using `Url` for path + query string manipulation.