### PR TITLE
Keep logs of package builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ example_projects/*/rv.lock
 from*/
 .DS_Store
 .aider*
+logs/

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -12,6 +12,7 @@ use url::Url;
 use crate::cache::utils::{
     get_current_system_path, get_packages_timeout, get_user_cache_dir, hash_string,
 };
+use crate::consts::BUILD_LOG_FILENAME;
 use crate::lockfile::Source;
 use crate::package::{BuiltinPackages, Package, get_builtin_versions_from_library};
 use crate::system_req::get_system_requirements;
@@ -165,7 +166,7 @@ impl DiskCache {
             p = p.join(version);
         }
 
-        p.join("build.log")
+        p.join(BUILD_LOG_FILENAME)
     }
 
     /// Gets the folder where a source tarball would be located

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -29,7 +29,6 @@ pub enum RCommandLookup {
     Skip,
 }
 
-
 impl From<Option<Version>> for RCommandLookup {
     /// convert Option<Version> to RCommandLookup, where if the Version is specified, it is a soft lookup
     /// If it is not specified, it is a strict lookup.
@@ -81,9 +80,7 @@ impl CliContext {
                 };
                 (v, r_cmd)
             }
-            RCommandLookup::Skip => {
-                (config.r_version().clone(), RCommandLine::default())
-            }
+            RCommandLookup::Skip => (config.r_version().clone(), RCommandLine::default()),
         };
 
         let cache = match DiskCache::new(&r_version, SystemInfo::from_os_info()) {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,6 +8,7 @@ pub const RV_DIR_NAME: &str = "rv";
 pub const LIBRARY_ROOT_DIR_NAME: &str = "library";
 pub const STAGING_DIR_NAME: &str = "__rv__staging";
 pub(crate) const LIBRARY_METADATA_FILENAME: &str = ".rv.metadata";
+pub const BUILD_LOG_FILENAME: &str = "__rv_build.log";
 
 /// How long are the package databases cached for
 /// Same default value as PKGCACHE_TIMEOUT:

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -138,6 +138,13 @@ impl Source {
         }
     }
 
+    pub fn git_url(&self) -> Option<&str> {
+        match self {
+            Source::Git { git, .. } => Some(git.url()),
+            _ => None,
+        }
+    }
+
     /// Some sources might have changed remotely so we will want to fetch them to be sure it
     /// hasn't changed (eg a git branch having new commits)
     pub fn could_have_changed(&self) -> bool {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -140,7 +140,7 @@ impl Source {
 
     pub fn git_url(&self) -> Option<&str> {
         match self {
-            Source::Git { git, .. } => Some(git.url()),
+            Source::Git { git, .. } | Source::RUniverse { git, .. } => Some(git.url()),
             _ => None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 use serde_json::json;
 
 use rv::cli::utils::timeit;
-use rv::cli::{find_r_repositories, init, init_structure, migrate_renv, tree, CliContext, RCommandLookup};
+use rv::cli::{
+    CliContext, RCommandLookup, find_r_repositories, init, init_structure, migrate_renv, tree,
+};
 use rv::system_req::{SysDep, SysInstallationStatus};
 use rv::{
     CacheInfo, Config, GitExecutor, Http, Lockfile, ProjectSummary, RCmd, RCommandLine, Resolution,
@@ -499,11 +501,20 @@ fn try_main() -> Result<()> {
                 ResolveMode::Default
             };
             let context = CliContext::new(&cli.config_file, r_version.into())?;
-            _sync(context, true, log_enabled, upgrade, output_format)?;
+            _sync(context, true, log_enabled, upgrade, output_format, None)?;
         }
-        Command::Sync {save_install_logs_in} => {
+        Command::Sync {
+            save_install_logs_in,
+        } => {
             let context = CliContext::new(&cli.config_file, RCommandLookup::Strict)?;
-            _sync(context, true, log_enabled, ResolveMode::Default, output_format, save_install_logs_in)?;
+            _sync(
+                context,
+                false,
+                log_enabled,
+                ResolveMode::Default,
+                output_format,
+                save_install_logs_in,
+            )?;
         }
         Command::Add {
             packages,
@@ -785,7 +796,7 @@ fn try_main() -> Result<()> {
         Command::Tree {
             depth,
             hide_system_deps,
-            r_version
+            r_version,
         } => {
             let mut context = CliContext::new(&cli.config_file, r_version.into())?;
             context.load_databases_if_needed()?;

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -223,7 +223,8 @@ impl<'d> Resolver<'d> {
                 .iter()
                 .chain(&package.suggests)
                 .map(|p| {
-                    let mut q = QueueItem::name_and_parent_only(Cow::Borrowed(p.name()), item.name.clone());
+                    let mut q =
+                        QueueItem::name_and_parent_only(Cow::Borrowed(p.name()), item.name.clone());
                     q.version_requirement = p.version_requirement().map(|x| Cow::Borrowed(x));
                     q
                 })
@@ -425,7 +426,8 @@ impl<'d> Resolver<'d> {
         http_download: &'d impl HttpDownload,
     ) -> Resolution<'d> {
         let mut result = Resolution::default();
-        let mut processed: HashMap<String, HashSet<Option<Cow<'d, VersionRequirement>>>> = HashMap::with_capacity(dependencies.len() * 10);
+        let mut processed: HashMap<String, HashSet<Option<Cow<'d, VersionRequirement>>>> =
+            HashMap::with_capacity(dependencies.len() * 10);
         // Top level dependencies can require specific repos.
         // We should not try to resolve those from anywhere else even if they dependencies of other
         // packages
@@ -462,7 +464,7 @@ impl<'d> Resolver<'d> {
             if let Some(ver_reqs) = processed.get(item.name.as_ref()) {
                 // If we have already found that dependency and it has a forced repo, skip it
                 if repo_required.contains(item.name.as_ref()) {
-                    continue
+                    continue;
                 }
 
                 // If there's no version requirement and we already have it, we can skip it
@@ -475,7 +477,10 @@ impl<'d> Resolver<'d> {
             if item.local_path.is_some() {
                 match self.local_lookup(&item) {
                     Ok((resolved_dep, items)) => {
-                        processed.entry(resolved_dep.name.to_string()).or_insert_with(HashSet::new).insert(item.version_requirement.clone());
+                        processed
+                            .entry(resolved_dep.name.to_string())
+                            .or_insert_with(HashSet::new)
+                            .insert(item.version_requirement.clone());
                         result.add_found(resolved_dep);
                         queue.extend(items);
                         continue;
@@ -491,7 +496,10 @@ impl<'d> Resolver<'d> {
             // is not listed from a specific repo
             if !item.has_required_repo() {
                 if let Some((resolved_dep, items)) = self.builtin_lookup(&item) {
-                    processed.entry(resolved_dep.name.to_string()).or_insert_with(HashSet::new).insert(item.version_requirement.clone());
+                    processed
+                        .entry(resolved_dep.name.to_string())
+                        .or_insert_with(HashSet::new)
+                        .insert(item.version_requirement.clone());
                     result.add_found(resolved_dep);
                     queue.extend(items);
                     continue;
@@ -500,7 +508,10 @@ impl<'d> Resolver<'d> {
 
             // Look at lockfile
             if let Some((resolved_dep, items)) = self.lockfile_lookup(&item, cache) {
-                processed.entry(resolved_dep.name.to_string()).or_insert_with(HashSet::new).insert(item.version_requirement.clone());
+                processed
+                    .entry(resolved_dep.name.to_string())
+                    .or_insert_with(HashSet::new)
+                    .insert(item.version_requirement.clone());
                 result.add_found(resolved_dep);
                 queue.extend(items);
                 continue;
@@ -508,7 +519,10 @@ impl<'d> Resolver<'d> {
 
             // Then we handle it differently depending on the source but even if we fail to find
             // something, we will consider it processed
-            processed.entry(item.name.to_string()).or_insert_with(HashSet::new).insert(item.version_requirement.clone());
+            processed
+                .entry(item.name.to_string())
+                .or_insert_with(HashSet::new)
+                .insert(item.version_requirement.clone());
 
             // But first, we check if the item has a remote and use that instead
             // We will keep the remote result around _if_ the item has a version requirement and is in

--- a/src/sync/changes.rs
+++ b/src/sync/changes.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
+use serde::{Serialize, Serializer};
+
+use crate::DiskCache;
 use crate::lockfile::Source;
 use crate::package::PackageType;
 use crate::system_req::{SysDep, SysInstallationStatus};
-use serde::{Serialize, Serializer};
 
 fn serialize_duration_as_ms<S>(
     duration: &Option<Duration>,
@@ -122,6 +125,22 @@ impl SyncChange {
             }
         } else {
             format!("- {}", self.name)
+        }
+    }
+
+    pub fn log_path(&self, cache: &DiskCache) -> PathBuf {
+        if let Some(s) = &self.source {
+            if s.is_repo() {
+                cache.get_build_log_path(
+                    s,
+                    Some(&self.name),
+                    Some(&self.version.clone().unwrap().as_str()),
+                )
+            } else {
+                cache.get_build_log_path(s, None, None)
+            }
+        } else {
+            unreachable!("Should not be called with uninstalled deps")
         }
     }
 }

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -120,6 +120,7 @@ impl<'a> SyncHandler<'a> {
                 dep,
                 self.project_dir,
                 &self.staging_path,
+                self.cache,
                 r_cmd,
                 cancellation,
             ),

--- a/src/system_req.rs
+++ b/src/system_req.rs
@@ -175,8 +175,8 @@ pub fn check_installation_status(
 
 #[cfg(test)]
 mod test {
-    use std::fs;
     use super::Response;
+    use std::fs;
 
     #[test]
     fn test_ubuntu_20_04() {


### PR DESCRIPTION
And a flag in rv sync to save them somewhere

```
cargo run --features=cli --release -- sync -c example_projects/test/rproject.toml --save-install-logs-in=logs


╰─ tree logs/
logs/
├── cli.log
├── glue.log
├── lifecycle.log
├── magrittr.log
├── pillar.log
├── pkgconfig.log
├── rlang.log
├── rv.remotes.log
├── tibble.log
├── utf8.log
└── vctrs.log
```