### PR TITLE
Sys Reqs, no packages

### DIFF
--- a/src/system_req.rs
+++ b/src/system_req.rs
@@ -46,6 +46,8 @@ impl SysDep {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Requirements {
+    // not all requirements have packages. Some are pre_/post_install
+    #[serde(default)]
     packages: Vec<String>,
 }
 

--- a/src/system_req.rs
+++ b/src/system_req.rs
@@ -172,3 +172,15 @@ pub fn check_installation_status(
 
     out
 }
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+    use super::Response;
+
+    #[test]
+    fn test_ubuntu_20_04() {
+        let content = fs::read_to_string("src/tests/sys_reqs/ubuntu_20.04.json").unwrap();
+        assert!(serde_json::from_str::<Response>(&content).is_ok());
+    }
+}

--- a/src/tests/sys_reqs/ubuntu_20.04.json
+++ b/src/tests/sys_reqs/ubuntu_20.04.json
@@ -1,0 +1,270 @@
+{
+  "requirements": [
+    {
+      "name": "ABC.RAP",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "AWR",
+      "requirements": {
+        "packages": [
+          "default-jdk"
+        ],
+        "install_scripts": [
+          "apt-get install -y default-jdk"
+        ],
+        "post_install": [
+          {
+            "command": "R CMD javareconf"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AovBay",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "BANOVA",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+      "name": "BCHM",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+      "name": "BGVAR",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "BIDistances",
+      "requirements": {
+        "packages": [
+          "make",
+          "pandoc"
+        ],
+        "install_scripts": [
+          "apt-get install -y make",
+          "apt-get install -y pandoc"
+        ]
+      }
+    },
+    {
+      "name": "BINtools",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "BPrinStratTTE",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "BSPBSS",
+      "requirements": {
+        "packages": [
+          "make"
+        ],
+        "install_scripts": [
+          "apt-get install -y make"
+        ]
+      }
+    },
+    {
+      "name": "BTSPAS",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+      "name": "BaHZING",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+      "name": "BayLum",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+      "name": "BayesCACE",
+      "requirements": {
+        "packages": [
+          "jags"
+        ],
+        "install_scripts": [
+          "apt-get install -y jags"
+        ]
+      }
+    },
+    {
+        "name": "RPushbullet",
+        "requirements": {
+            "pre_install": [
+            {
+                "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+            }
+            ],
+            "post_install": [
+            {
+                "command": "rm -f /tmp/google-chrome.deb"
+            }
+            ]
+        }
+    },
+    {
+        "name": "chromote",
+        "requirements": {
+            "pre_install": [
+            {
+                "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+            }
+            ],
+            "post_install": [
+            {
+                "command": "rm -f /tmp/google-chrome.deb"
+            }
+            ]
+        }
+    },
+    {
+        "name": "giacR",
+        "requirements": {
+            "pre_install": [
+            {
+                "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+            }
+            ],
+            "post_install": [
+            {
+                "command": "rm -f /tmp/google-chrome.deb"
+            }
+            ]
+        }
+    },
+    {
+        "name": "nomnoml",
+        "requirements": {
+            "pre_install": [
+            {
+                "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+            }
+            ],
+            "post_install": [
+            {
+                "command": "rm -f /tmp/google-chrome.deb"
+            }
+            ]
+        }
+    },
+    {
+        "name": "qtkit",
+        "requirements": {
+            "pre_install": [
+            {
+                "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            },
+            {
+                "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+            }
+            ],
+            "post_install": [
+            {
+                "command": "rm -f /tmp/google-chrome.deb"
+            }
+            ]
+        }
+    }
+  ]
+}


### PR DESCRIPTION
In `https://packagemanager.posit.co/__api__/repos/cran/sysreqs?all=true&distribution=ubuntu&release=20.04`, not all requirements have packages associated with them, leading to the following panic:

![image](https://github.com/user-attachments/assets/3db8e7bc-c410-401c-8fe0-a7fe3ee3e3cb)

After some investigation, I found these:

```
$ curl "https://packagemanager.posit.co/__api__/repos/cran/sysreqs?all=true&distribution=ubuntu&release=20.04"   | jq '.' | tee sysreq.json
$ jq '.requirements[] | select(.requirements.packages == null)' sysreq.json > logger.log
```

```
{
  "name": "RPushbullet",
  "requirements": {
    "pre_install": [
      {
        "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
      },
      {
        "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
      },
      {
        "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
      }
    ],
    "post_install": [
      {
        "command": "rm -f /tmp/google-chrome.deb"
      }
    ]
  }
}
{
  "name": "chromote",
  "requirements": {
    "pre_install": [
      {
        "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
      },
      {
        "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
      },
      {
        "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
      }
    ],
    "post_install": [
      {
        "command": "rm -f /tmp/google-chrome.deb"
      }
    ]
  }
}
{
  "name": "giacR",
  "requirements": {
    "pre_install": [
      {
        "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
      },
      {
        "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
      },
      {
        "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
      }
    ],
    "post_install": [
      {
        "command": "rm -f /tmp/google-chrome.deb"
      }
    ]
  }
}
{
  "name": "nomnoml",
  "requirements": {
    "pre_install": [
      {
        "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
      },
      {
        "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
      },
      {
        "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
      }
    ],
    "post_install": [
      {
        "command": "rm -f /tmp/google-chrome.deb"
      }
    ]
  }
}
{
  "name": "qtkit",
  "requirements": {
    "pre_install": [
      {
        "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
      },
      {
        "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
      },
      {
        "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
      }
    ],
    "post_install": [
      {
        "command": "rm -f /tmp/google-chrome.deb"
      }
    ]
  }
}
```

This does not exist on 22.04 or 24.04 (haven't tested any other distros), 

Test does not pass if #[serde(default)] in `Packages` is commented out