### PR TITLE
R Command Lookup not required for info commands

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,4 +3,4 @@ mod context;
 pub mod utils;
 
 pub use commands::{find_r_repositories, init, init_structure, migrate_renv, tree};
-pub use context::CliContext;
+pub use context::{CliContext, RCommandLookup};


### PR DESCRIPTION
Currently, the R version has to be found on the system for commands like `library, `cache, `info`, etc, even though the R command is never used. This PR makes it so that there are 3 levels to the R Command Lookup:
* strict - enforce the R version specified must be found on the system
* soft - if the `--r-version` flag is used on planning commands, we do not require the R Command to be found
* skip - if the R command is never used, there is no need to look for it

Below is evidence of how these changes impact various commands:

The `--r-version` in init never was used to look up the R command in the first place, but included here since it was used to initialize the config and to prove it still is not used.
```
$ cargo run --all-features -- init --r-version 4.6
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s
     Running `/Users/wescummings/projects/rv/target/debug/rv init --r-version 4.6`
rv project successfully initialized at .
```

Config file with an R version that is not released:
```
[project]
name = "cache-test"
r_version = "4.6"

repositories = [
    {alias = "CRAN", url = "https://cloud.r-project.org/"},
]

dependencies = [

]
```

Cache and Library work now
```
$ ../target/debug/rv cache
/Users/wescummings/.cache/rv
CRAN (https://cloud.r-project.org/ -> 66bf25474b), path: /Users/wescummings/.cache/rv/66bf25474b

$ ./target/debug/rv cache
rv/library/4.6/arm64
```

Add deps, but do not sync used add
```
$ ../target/debug/rv add ggplot2 --no-sync
Packages successfully added
```

Plan with a different r-version not on the system
```
$ ../target/debug/rv plan --r-version=4.7

+ cli (3.6.5, source from https://cloud.r-project.org/)
+ farver (2.1.2, source from https://cloud.r-project.org/)
+ ggplot2 (3.5.2, source from https://cloud.r-project.org/)
+ glue (1.8.0, source from https://cloud.r-project.org/)
+ gtable (0.3.6, source from https://cloud.r-project.org/)
+ isoband (0.2.7, source from https://cloud.r-project.org/)
+ labeling (0.4.3, source from https://cloud.r-project.org/)
+ lattice (0.22-7, source from https://cloud.r-project.org/)
+ lifecycle (1.0.4, source from https://cloud.r-project.org/)
+ magrittr (2.0.3, source from https://cloud.r-project.org/)
+ MASS (7.3-65, source from https://cloud.r-project.org/)
+ Matrix (1.7-3, source from https://cloud.r-project.org/)
+ mgcv (1.9-3, source from https://cloud.r-project.org/)
+ nlme (3.1-168, source from https://cloud.r-project.org/)
+ pillar (1.10.2, source from https://cloud.r-project.org/)
+ pkgconfig (2.0.3, source from https://cloud.r-project.org/)
+ R6 (2.6.1, source from https://cloud.r-project.org/)
+ RColorBrewer (1.1-3, source from https://cloud.r-project.org/)
+ rlang (1.1.6, source from https://cloud.r-project.org/)
+ scales (1.4.0, source from https://cloud.r-project.org/)
+ tibble (3.3.0, source from https://cloud.r-project.org/)
+ utf8 (1.2.6, source from https://cloud.r-project.org/)
+ vctrs (0.6.5, source from https://cloud.r-project.org/)
+ viridisLite (0.4.2, source from https://cloud.r-project.org/)
+ withr (3.0.2, source from https://cloud.r-project.org/)
```

Summary with an r-version on the system
```
$ ../target/debug/rv summary --r-version=4.4
== System Information == 
OS: macos (arm64)
R Version: 4.4

Num Workers for Sync: 8 (8 cpus available)
Cache Location: /Users/wescummings/.cache/rv

== Dependencies == 
Library: rv/library/4.4/arm64
Installed: 0/25

Package Sources: 
  CRAN: 0/20 binary packages
  builtin: 0/5 binary packages

Installation Summary: 
  CRAN: 20/20 to download
  builtin: 5/5 in cache

== Remote == 
CRAN (https://cloud.r-project.org/): 23445 binary packages, 22323 source packages
```

Summary without `--r-version` fails
```
$ ../target/debug/rv summary

Failed to get R version

Caused by:
    Specified R version (4.6) does not match any available versions found on the system (4.4.3)
```