### PR TITLE
Default to trusting the library when not using lockfiles

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,7 @@ fn _sync(
             if !has_logs_enabled {
                 handler.show_progress_bar();
             }
-            handler.set_has_lockfile(context.lockfile.is_some());
+            handler.set_uses_lockfile(context.config.use_lockfile());
             handler.handle(&resolved, &context.r_cmd)
         }
     ) {

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -203,14 +203,12 @@ impl RCmd for RCommandLine {
         env_vars: &HashMap<&str, &str>,
     ) -> Result<String, InstallError> {
         // the core library will be the first library in the list
-        let library = libraries
-            .first()
-            .ok_or_else(|| InstallError {
-                source: InstallErrorKind::InstallationFailed(
-                    "No library specified for R CMD INSTALL".to_string(),
-                ),
-            })?;
-   
+        let library = libraries.first().ok_or_else(|| InstallError {
+            source: InstallErrorKind::InstallationFailed(
+                "No library specified for R CMD INSTALL".to_string(),
+            ),
+        })?;
+
         // Always delete destination if it exists first to avoid issues with incomplete installs
         // except if it's the same as the library. This happens for local packages
         if library.as_ref() != destination.as_ref() {
@@ -233,14 +231,13 @@ impl RCmd for RCommandLine {
             .map_err(|e| InstallError {
                 source: InstallErrorKind::LinkError(e),
             })?;
-        
 
         let canonicalized_libraries = libraries
             .iter()
             .map(|lib| lib.as_ref().canonicalize())
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| InstallError::from_fs_io(e, destination.as_ref()))?;
-        
+
         // combine them to the single string path that R wants, specifically:
         //  colon-separated on Unix-alike systems and semicolon-separated on Windows.
         let library_paths = if cfg!(windows) {


### PR DESCRIPTION
```
╭─ ~/Code/a2-ai/rv  trust-no-lockfile ·························································································································································································································································· ✔  16:06:39 
╰─ cargo run --release --features=cli -- sync -c example_projects/no-lockfile/rproject.toml
    Finished `release` profile [optimized] target(s) in 0.13s
     Running `target/release/rv sync -c example_projects/no-lockfile/rproject.toml`
Nothing to do
```