### PR TITLE
`dependencies_only` to be remove

### DIFF
--- a/src/sync/changes.rs
+++ b/src/sync/changes.rs
@@ -22,7 +22,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 pub struct SyncChange {
     pub name: String,
     #[serde(skip)]

--- a/src/system_req.rs
+++ b/src/system_req.rs
@@ -29,7 +29,7 @@ impl fmt::Display for SysInstallationStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SysDep {
     pub name: String,
     pub status: SysInstallationStatus,


### PR DESCRIPTION
If a package was installed, then the dep moves to be `dependencies_only = true`, this was not captured as a package to be removed. This caused integer underflow since the number of packages installed was greater than the number of packages to install and resulted in the process hanging since it did not know how to handle the, now removed, package.

Additionally, it was observed during testing that some sync changes were printed in duplicate, therefore dedup was added.

### `dependencies_only` no longer hangs

Config:
```
[project]
name = "deps_only"
r_version = "4.4"

repositories = [
    {alias = "PRISM", url = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27"},
]

dependencies = [
    #{ name = "dplyr", dependencies_only = true },
    #"dplyr",
]
```

First, with simple `dplyr` uncommented
```
$ rv sync
+ cli (3.6.5, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 1ms
+ dplyr (1.1.4, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ fansi (1.0.6, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 2ms
+ generics (0.1.4, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ glue (1.8.0, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 2ms
+ lifecycle (1.0.4, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ magrittr (2.0.3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ pillar (1.10.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ pkgconfig (2.0.3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ R6 (2.6.1, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ rlang (1.1.6, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ tibble (3.2.1, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ tidyselect (1.2.1, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ utf8 (1.2.5, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 1ms
+ vctrs (0.6.5, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ withr (3.0.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
```

Then, with `dependencies_only = true` uncommented (and simple `dplyr` commented out):
```
$ rv sync
- dplyr
```

### displayed sync changes with/without duplicates
I've seen this a couple times with Andrew (and myself) on other removals, not just this dependencies_only change, but this is the reproducible situation I'm able to get:

Config:
```
[project]
name = "deps_only"
r_version = "4.4"

repositories = [
    {alias = "PRISM", url = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27"},
]

dependencies = [
    #{ name = "dplyr", dependencies_only = true },
    #"dplyr",
    #"ggplot2",
]
```

1. sync with only simple `dplyr` uncommented behaves as expected
2. sync with `dependencies_only` `dplyr` line and `ggplot2` uncommented and simple `dplyr` commented out:
     a. Without dedup line:
```
% rv sync
- dplyr
- dplyr
+ farver (2.1.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 1ms
+ ggplot2 (3.5.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ gtable (0.3.6, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ isoband (0.2.7, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ labeling (0.4.3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ RColorBrewer (1.1-3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ scales (1.4.0, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ viridisLite (0.4.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
```
    b. With dedup line:
```
% rv sync
- dplyr
+ farver (2.1.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 1ms
+ ggplot2 (3.5.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ gtable (0.3.6, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ isoband (0.2.7, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ labeling (0.4.3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ RColorBrewer (1.1-3, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ scales (1.4.0, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
+ viridisLite (0.4.2, binary from https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-05-27) in 0ms
```
     