### PR TITLE
Local -> Git Sha panic

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -182,7 +182,7 @@ impl Library {
             | Source::RUniverse { ref sha, .. } => self
                 .non_repo_packages
                 .get(pkg.name.as_ref())
-                .map(|m| m.sha().unwrap() == sha.as_str())
+                .and_then(|m| m.sha().map(|s| s == sha.as_str()))
                 .unwrap_or(false),
             Source::Local { ref sha, .. } => {
                 if let Some(metadata) = self.non_repo_packages.get(pkg.name.as_ref()) {


### PR DESCRIPTION
Converting an installed packages from a local source (or any non_repo_source) was found to manic when converting to a git source since the LocalMetadata expected to find a sha, but is not always present. This change allows for the change to work as expected:

Config
```
[project]
name = "sha-test"
r_version = "4.4"

repositories = [
    {alias = "CRAN", url = "https://cloud.r-project.org/"},
]

dependencies = [
    { name = "ghqc", path = "../../../packages/ghqc" },
    #{ name = "ghqc", git = "https://github.com/a2-ai/ghqc", branch = "main" }
]
```

Initially sync with path works as expected.
Convert to git dependency and have the following results:

With rv 0.9.0
```
wescummings@WES sha-test % rv sync

thread 'main' panicked at src/library.rs:185:34:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With fix
```
wescummings@WES sha-test % cargo run --all-features -- sync
   Compiling env_home v0.1.0
   Compiling which v8.0.0
   Compiling rv v0.9.0 (/Users/wescummings/projects/rv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.60s
     Running `/Users/wescummings/projects/rv/target/debug/rv sync`
- ghqc
- ghqc
+ ghqc (0.5.0, source from https://github.com/a2-ai/ghqc (branch: main)) in 1107ms
```