### PR TITLE
Local mtime check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "rv"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -46,7 +46,7 @@ fn metadata(path: impl AsRef<Path>) -> Result<Metadata, std::io::Error> {
 /// We keep it simple for now and just mtime even if it causes more rebuilds than mtime + hashes
 pub(crate) fn mtime_recursive(folder: impl AsRef<Path>) -> Result<FileTime, std::io::Error> {
     let meta = metadata(folder.as_ref())?;
-    if !meta.is_file() {
+    if !meta.is_dir() {
         return Ok(FileTime::from_last_modification_time(&meta));
     }
 


### PR DESCRIPTION
Bug in checking if local mtime has changed.

Before (with mtime printed)
```
% cargo run --all-features -- -c example_projects/local-deps/rproject.toml sync -vvv
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/rv -c example_projects/local-deps/rproject.toml sync -vvv`
[2025-07-02T17:06:44Z DEBUG rv::r_cmd] R 4.4 found on the path
[2025-07-02T17:06:44Z DEBUG rv::resolver::sat] Solving dependencies for 2 packages and 0 version requirements
[2025-07-02T17:06:44Z DEBUG rv::resolver::sat] Starting SAT solving
[2025-07-02T17:06:44Z INFO  rv::resolver::sat] SAT solving completed in 15.5µs, found 2 packages
1745422214
FileTime {
    seconds: 1745422214,
    nanos: 320938195,
}
[2025-07-02T17:06:44Z INFO  rv] Synced dependencies in 0ms
Nothing to do
```

After (with mtime printed)
```
% cargo run --all-features -- -c example_projects/local-deps/rproject.toml sync -vvv
   Compiling rv v0.10.0 (/Users/wescummings/projects/rv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.38s
     Running `target/debug/rv -c example_projects/local-deps/rproject.toml sync -vvv`
[2025-07-02T17:10:04Z DEBUG rv::r_cmd] R 4.4 found on the path
[2025-07-02T17:10:04Z DEBUG rv::resolver::sat] Solving dependencies for 2 packages and 0 version requirements
[2025-07-02T17:10:04Z DEBUG rv::resolver::sat] Starting SAT solving
[2025-07-02T17:10:04Z INFO  rv::resolver::sat] SAT solving completed in 16.084µs, found 2 packages
1745422214
FileTime {
    seconds: 1751476002,
    nanos: 679193991,
}
[2025-07-02T17:10:04Z DEBUG rv::sync::handler] Packages with files loaded (via lsof): {}
[2025-07-02T17:10:04Z DEBUG rv::sync::handler] Installing dummy (source) on worker 1
[2025-07-02T17:10:04Z DEBUG rv::sync::sources::local] Building the local package in /Users/wescummings/projects/rv/dummy-pkg
[2025-07-02T17:10:04Z DEBUG rv::sync::link] Linking package from /Users/wescummings/projects/rv/dummy-pkg to /var/folders/n_/p8p3xyjn17j46vzr511810900000gn/T/.tmpKWOUge using symlinks
[2025-07-02T17:10:04Z DEBUG rv::r_cmd] Compiling /Users/wescummings/projects/rv/dummy-pkg with env vars: R_LIBS_SITE=/Users/wescummings/projects/rv/example_projects/local-deps/rv/__rv__staging:/Users/wescummings/projects/rv/example_projects/local-deps/rv/library/4.4/arm64 R_LIBS_USER=/Users/wescummings/projects/rv/example_projects/local-deps/rv/__rv__staging:/Users/wescummings/projects/rv/example_projects/local-deps/rv/library/4.4/arm64 _R_SHLIB_STRIP_=true
[2025-07-02T17:10:05Z DEBUG rv::sync::handler] Completed installing dummy (1/1)
[2025-07-02T17:10:05Z DEBUG rv::sync::handler] Removing dummy from library
[2025-07-02T17:10:05Z INFO  rv] Synced dependencies in 770ms
- dummy
+ dummy (0.0.0.9001, source from  ../../dummy-pkg/) in 520ms
```