### PR TITLE
recognize builtins as installed in summary

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -172,7 +172,10 @@ impl Library {
     }
 
     pub fn contains_package(&self, pkg: &ResolvedDependency) -> bool {
-        if self.custom || !self.packages.contains_key(pkg.name.as_ref()) {
+        if self.custom
+            || (!self.packages.contains_key(pkg.name.as_ref())
+                && !matches!(pkg.source, Source::Builtin { .. }))
+        {
             return false;
         }
 


### PR DESCRIPTION
Before
```
== System Information == 
OS: macos (arm64)
R Version: 4.4

Num Workers for Sync: 8 (8 cpus available)
Cache Location: /Users/wescummings/.cache/rv

== Dependencies == 
Library: rv/library/4.4/arm64
Installed: 109/114

Package Sources: 
  PPM: 109/109 binary packages
  builtin: 0/5 binary packages

Installation Summary: 
  builtin: 5/5 in cache

== Remote == 
PPM (https://packagemanager.posit.co/cran/latest): 19549 binary packages, 22377 source packages
```

After
```
== System Information == 
OS: macos (arm64)
R Version: 4.4

Num Workers for Sync: 8 (8 cpus available)
Cache Location: /Users/wescummings/.cache/rv

== Dependencies == 
Library: rv/library/4.4/arm64
Installed: 114/114

Package Sources: 
  PPM: 109/109 binary packages
  builtin: 5/5 binary packages

== Remote == 
PPM (https://packagemanager.posit.co/cran/latest): 19549 binary packages, 22377 source packages
```