### PR TITLE
added filtering to tree command to show only paths that lead to targe…

### DIFF
--- a/src/cli/commands/tree.rs
+++ b/src/cli/commands/tree.rs
@@ -290,6 +290,10 @@ pub struct Tree<'a> {
 }
 
 impl Tree<'_> {
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
     pub fn print(&self, max_depth: Option<usize>, show_sys_deps: bool) {
         for (i, tree) in self.nodes.iter().enumerate() {
             let dup_marker = if tree.is_duplicate { " (*)" } else { "" };
@@ -323,182 +327,125 @@ impl Tree<'_> {
     }
 }
 
-/// Builds inverted tree showing which top-level dependencies depend on the target package
-fn build_inverted_tree<'a>(
-    original_trees: Vec<TreeNode<'a>>,
-    target_package: &'a str,
-    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
-    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
-    context: &'a Context,
-) -> Vec<TreeNode<'a>> {
-    let mut inverted_trees = Vec::new();
+fn dependents_by_name<'d>(
+    resolved_deps: &'d [ResolvedDependency],
+) -> HashMap<&'d str, Vec<&'d ResolvedDependency<'d>>> {
+    let mut out: HashMap<_, Vec<&'d ResolvedDependency>> = HashMap::new();
+    for dep in resolved_deps {
+        for name in dep.all_dependencies_names() {
+            out.entry(name).or_default().push(dep);
+        }
+    }
+    for dependents in out.values_mut() {
+        dependents.sort_unstable_by_key(|d| d.name.as_ref());
+    }
+    out
+}
 
-    // For each top-level dependency, check if it has the target package in its tree
-    for top_level_tree in original_trees {
-        if let Some(inverted_subtree) = find_and_invert_paths(
-            &top_level_tree,
-            target_package,
-            deps_by_name,
-            unresolved_deps_by_name,
+fn recursive_dependent_finder<'d>(
+    dep: &'d ResolvedDependency,
+    dependents: &HashMap<&'d str, Vec<&'d ResolvedDependency<'d>>>,
+    context: &'d Context,
+    ancestors: &mut Vec<&'d str>,
+    visited: &mut HashSet<&'d str>,
+) -> TreeNode<'d> {
+    let name = dep.name.as_ref();
+    let sys_deps = context.system_dependencies.get(name);
+
+    if ancestors.contains(&name) {
+        return TreeNode::resolved(name, dep, sys_deps, vec![]);
+    }
+
+    if visited.contains(name) {
+        return TreeNode::duplicate(name, dep, sys_deps);
+    }
+    visited.insert(name);
+
+    ancestors.push(name);
+    let children = dependents
+        .get(name)
+        .map(|found| {
+            found
+                .iter()
+                .map(|d| recursive_dependent_finder(d, dependents, context, ancestors, visited))
+                .collect()
+        })
+        .unwrap_or_default();
+    ancestors.pop();
+
+    TreeNode::resolved(name, dep, sys_deps, children)
+}
+
+fn inverted_tree<'d>(
+    target: &str,
+    resolved_deps: &'d [ResolvedDependency],
+    unresolved_deps_by_name: &HashMap<&'d str, &'d UnresolvedDependency>,
+    context: &'d Context,
+) -> Vec<TreeNode<'d>> {
+    let dependents = dependents_by_name(resolved_deps);
+    let mut ancestors = Vec::new();
+    let mut visited = HashSet::new();
+
+    if let Some(dep) = resolved_deps.iter().find(|d| d.name.as_ref() == target) {
+        return vec![recursive_dependent_finder(
+            dep,
+            &dependents,
             context,
-        ) {
-            // Create tree with top-level as root and target as child
-            let mut top_level_node = top_level_tree;
-            top_level_node.children = vec![inverted_subtree];
-            inverted_trees.push(top_level_node);
-        }
+            &mut ancestors,
+            &mut visited,
+        )];
     }
 
-    inverted_trees
-}
+    // A package can be depended on without being resolved itself, so it still gets a tree
+    let Some((name, unresolved)) = unresolved_deps_by_name.get_key_value(target) else {
+        return Vec::new();
+    };
+    let mut node = TreeNode::unresolved(
+        name,
+        Some(unresolved),
+        context.system_dependencies.get(*name),
+    );
+    visited.insert(*name);
+    ancestors.push(*name);
+    node.children = dependents
+        .get(*name)
+        .map(|found| {
+            found
+                .iter()
+                .map(|d| {
+                    recursive_dependent_finder(
+                        d,
+                        &dependents,
+                        context,
+                        &mut ancestors,
+                        &mut visited,
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
-/// Finds the target package in a tree and builds inverted paths from target back to dependents
-fn find_and_invert_paths<'a>(
-    node: &TreeNode<'a>,
-    target_package: &'a str,
-    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
-    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
-    context: &'a Context,
-) -> Option<TreeNode<'a>> {
-    // If this node is the target, create target node with inverted dependencies
-    if node.name == target_package {
-        return Some(create_target_node_with_dependents(
-            target_package,
-            deps_by_name,
-            unresolved_deps_by_name,
-            context,
-        ));
-    }
-
-    // Otherwise, recursively check children
-    for child in &node.children {
-        if let Some(inverted_child) = find_and_invert_paths(
-            child,
-            target_package,
-            deps_by_name,
-            unresolved_deps_by_name,
-            context,
-        ) {
-            return Some(inverted_child);
-        }
-    }
-
-    None
-}
-
-/// Creates a target node with its dependents as children (inverted dependencies)
-fn create_target_node_with_dependents<'a>(
-    target_package: &'a str,
-    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
-    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
-    context: &'a Context,
-) -> TreeNode<'a> {
-    // Find all packages that directly depend on the target
-    let mut dependents = Vec::new();
-
-    for (name, dep) in deps_by_name {
-        if dep.all_dependencies_names().contains(&target_package) {
-            // Only include this dependent if it's not a different top-level dependency
-            // We need to know which top-level we're building for, so we'll get it from the context
-            // For now, we'll need to pass this information differently
-            let mut visited = HashSet::new();
-            visited.insert(target_package);
-            let dependent_node = build_dependent_chain_with_cycle_detection(
-                name,
-                target_package,
-                "", // We'll fix this by restructuring the function calls
-                deps_by_name,
-                context,
-                &mut visited,
-            );
-            dependents.push(dependent_node);
-        }
-    }
-
-    // Create the target node with dependents as children
-    let sys_deps = context.system_dependencies.get(target_package);
-    if let Some(dep) = deps_by_name.get(target_package).copied() {
-        TreeNode::resolved(target_package, dep, sys_deps, dependents)
-    } else {
-        let mut node = TreeNode::unresolved(
-            target_package,
-            unresolved_deps_by_name.get(target_package).copied(),
-            sys_deps,
-        );
-        node.children = dependents;
-        node
-    }
-}
-
-/// Builds a chain of dependents from a package that depends on the target with cycle detection
-fn build_dependent_chain_with_cycle_detection<'a>(
-    package_name: &'a str,
-    target_package: &'a str,
-    current_top_level: &'a str,
-    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
-    context: &'a Context,
-    visited: &mut HashSet<&'a str>,
-) -> TreeNode<'a> {
-    let dep = deps_by_name[&package_name];
-
-    // Add this package to visited set
-    visited.insert(package_name);
-
-    // Find packages that depend on this package (but not ones we've already visited)
-    let mut higher_dependents = Vec::new();
-    for (name, higher_dep) in deps_by_name {
-        if *name != target_package
-            && !visited.contains(name)
-            && higher_dep.all_dependencies_names().contains(&package_name)
-        {
-            // Only continue if this is the current top-level dependency we're building for
-            // or if it's not a top-level dependency at all
-            if *name == current_top_level || !is_top_level_dependency(name, context) {
-                let higher_dependent_node = build_dependent_chain_with_cycle_detection(
-                    name,
-                    target_package,
-                    current_top_level,
-                    deps_by_name,
-                    context,
-                    visited,
-                );
-                higher_dependents.push(higher_dependent_node);
-            }
-        }
-    }
-
-    // Remove this package from visited set (backtrack)
-    visited.remove(package_name);
-
-    TreeNode::resolved(
-        package_name,
-        dep,
-        context.system_dependencies.get(package_name),
-        higher_dependents,
-    )
-}
-
-/// Helper function to check if a package is a top-level dependency
-fn is_top_level_dependency(package_name: &str, context: &Context) -> bool {
-    context
-        .config
-        .dependencies()
-        .iter()
-        .any(|dep| dep.name() == package_name)
+    vec![node]
 }
 
 pub fn tree<'a>(
     context: &'a Context,
     resolved_deps: &'a [ResolvedDependency],
     unresolved_deps: &'a [UnresolvedDependency],
-    invert_target: Option<&'a str>,
+    invert_target: Option<&str>,
 ) -> Tree<'a> {
-    let deps_by_name: HashMap<_, _> = resolved_deps.iter().map(|d| (d.name.as_ref(), d)).collect();
     let unresolved_deps_by_name: HashMap<_, _> = unresolved_deps
         .iter()
         .map(|d| (d.name.as_ref(), d))
         .collect();
 
+    if let Some(target) = invert_target {
+        return Tree {
+            nodes: inverted_tree(target, resolved_deps, &unresolved_deps_by_name, context),
+        };
+    }
+
+    let deps_by_name: HashMap<_, _> = resolved_deps.iter().map(|d| (d.name.as_ref(), d)).collect();
     let mut nodes = Vec::new();
     let mut visited: HashSet<&str> = HashSet::new();
 
@@ -525,18 +472,6 @@ pub fn tree<'a>(
             ));
         }
     }
-
-    let nodes = if let Some(target_package) = invert_target {
-        build_inverted_tree(
-            nodes,
-            target_package,
-            &deps_by_name,
-            &unresolved_deps_by_name,
-            context,
-        )
-    } else {
-        nodes
-    };
 
     Tree { nodes }
 }

--- a/src/cli/commands/tree.rs
+++ b/src/cli/commands/tree.rs
@@ -323,10 +323,175 @@ impl Tree<'_> {
     }
 }
 
+/// Builds inverted tree showing which top-level dependencies depend on the target package
+fn build_inverted_tree<'a>(
+    original_trees: Vec<TreeNode<'a>>,
+    target_package: &'a str,
+    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
+    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
+    context: &'a Context,
+) -> Vec<TreeNode<'a>> {
+    let mut inverted_trees = Vec::new();
+
+    // For each top-level dependency, check if it has the target package in its tree
+    for top_level_tree in original_trees {
+        if let Some(inverted_subtree) = find_and_invert_paths(
+            &top_level_tree,
+            target_package,
+            deps_by_name,
+            unresolved_deps_by_name,
+            context,
+        ) {
+            // Create tree with top-level as root and target as child
+            let mut top_level_node = top_level_tree;
+            top_level_node.children = vec![inverted_subtree];
+            inverted_trees.push(top_level_node);
+        }
+    }
+
+    inverted_trees
+}
+
+/// Finds the target package in a tree and builds inverted paths from target back to dependents
+fn find_and_invert_paths<'a>(
+    node: &TreeNode<'a>,
+    target_package: &'a str,
+    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
+    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
+    context: &'a Context,
+) -> Option<TreeNode<'a>> {
+    // If this node is the target, create target node with inverted dependencies
+    if node.name == target_package {
+        return Some(create_target_node_with_dependents(
+            target_package,
+            deps_by_name,
+            unresolved_deps_by_name,
+            context,
+        ));
+    }
+
+    // Otherwise, recursively check children
+    for child in &node.children {
+        if let Some(inverted_child) = find_and_invert_paths(
+            child,
+            target_package,
+            deps_by_name,
+            unresolved_deps_by_name,
+            context,
+        ) {
+            return Some(inverted_child);
+        }
+    }
+
+    None
+}
+
+/// Creates a target node with its dependents as children (inverted dependencies)
+fn create_target_node_with_dependents<'a>(
+    target_package: &'a str,
+    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
+    unresolved_deps_by_name: &HashMap<&'a str, &'a UnresolvedDependency>,
+    context: &'a Context,
+) -> TreeNode<'a> {
+    // Find all packages that directly depend on the target
+    let mut dependents = Vec::new();
+
+    for (name, dep) in deps_by_name {
+        if dep.all_dependencies_names().contains(&target_package) {
+            // Only include this dependent if it's not a different top-level dependency
+            // We need to know which top-level we're building for, so we'll get it from the context
+            // For now, we'll need to pass this information differently
+            let mut visited = HashSet::new();
+            visited.insert(target_package);
+            let dependent_node = build_dependent_chain_with_cycle_detection(
+                name,
+                target_package,
+                "", // We'll fix this by restructuring the function calls
+                deps_by_name,
+                context,
+                &mut visited,
+            );
+            dependents.push(dependent_node);
+        }
+    }
+
+    // Create the target node with dependents as children
+    let sys_deps = context.system_dependencies.get(target_package);
+    if let Some(dep) = deps_by_name.get(target_package).copied() {
+        TreeNode::resolved(target_package, dep, sys_deps, dependents)
+    } else {
+        let mut node = TreeNode::unresolved(
+            target_package,
+            unresolved_deps_by_name.get(target_package).copied(),
+            sys_deps,
+        );
+        node.children = dependents;
+        node
+    }
+}
+
+/// Builds a chain of dependents from a package that depends on the target with cycle detection
+fn build_dependent_chain_with_cycle_detection<'a>(
+    package_name: &'a str,
+    target_package: &'a str,
+    current_top_level: &'a str,
+    deps_by_name: &HashMap<&'a str, &'a ResolvedDependency>,
+    context: &'a Context,
+    visited: &mut HashSet<&'a str>,
+) -> TreeNode<'a> {
+    let dep = deps_by_name[&package_name];
+
+    // Add this package to visited set
+    visited.insert(package_name);
+
+    // Find packages that depend on this package (but not ones we've already visited)
+    let mut higher_dependents = Vec::new();
+    for (name, higher_dep) in deps_by_name {
+        if *name != target_package
+            && !visited.contains(name)
+            && higher_dep.all_dependencies_names().contains(&package_name)
+        {
+            // Only continue if this is the current top-level dependency we're building for
+            // or if it's not a top-level dependency at all
+            if *name == current_top_level || !is_top_level_dependency(name, context) {
+                let higher_dependent_node = build_dependent_chain_with_cycle_detection(
+                    name,
+                    target_package,
+                    current_top_level,
+                    deps_by_name,
+                    context,
+                    visited,
+                );
+                higher_dependents.push(higher_dependent_node);
+            }
+        }
+    }
+
+    // Remove this package from visited set (backtrack)
+    visited.remove(package_name);
+
+    TreeNode::resolved(
+        package_name,
+        dep,
+        context.system_dependencies.get(package_name),
+        higher_dependents,
+    )
+}
+
+/// Helper function to check if a package is a top-level dependency
+fn is_top_level_dependency(package_name: &str, context: &Context) -> bool {
+    context
+        .config
+        .dependencies()
+        .iter()
+        .any(|dep| dep.name() == package_name)
+}
+
 pub fn tree<'a>(
     context: &'a Context,
     resolved_deps: &'a [ResolvedDependency],
     unresolved_deps: &'a [UnresolvedDependency],
+    invert_target: Option<&'a str>,
 ) -> Tree<'a> {
     let deps_by_name: HashMap<_, _> = resolved_deps.iter().map(|d| (d.name.as_ref(), d)).collect();
     let unresolved_deps_by_name: HashMap<_, _> = unresolved_deps
@@ -360,6 +525,18 @@ pub fn tree<'a>(
             ));
         }
     }
+
+    let nodes = if let Some(target_package) = invert_target {
+        build_inverted_tree(
+            nodes,
+            target_package,
+            &deps_by_name,
+            &unresolved_deps_by_name,
+            context,
+        )
+    } else {
+        nodes
+    };
 
     Tree { nodes }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -945,6 +945,14 @@ fn try_main() -> Result<()> {
                 invert.as_deref(),
             );
 
+            if let Some(target) = &invert
+                && tree.is_empty()
+            {
+                return Err(anyhow!(
+                    "Package `{target}` is not in the resolved dependency tree"
+                ));
+            }
+
             if output_format.is_json() {
                 println!(
                     "{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,9 @@ pub enum Command {
         /// Specify an R version different from the one in the config.
         /// The command will not error even if this R version is not found
         r_version: Option<Version>,
+        #[clap(long)]
+        /// Invert the tree to show which top-level dependencies depend on the specified package
+        invert: Option<String>,
     },
     /// Returns the path for the library for the current project/system in UNIX format, even
     /// on Windows.
@@ -923,6 +926,7 @@ fn try_main() -> Result<()> {
             depth,
             hide_system_deps,
             r_version,
+            invert,
         } => {
             let mut context =
                 Context::new(&cli.config_file, r_version.into()).map_err(|e| anyhow!("{e}"))?;
@@ -934,7 +938,12 @@ fn try_main() -> Result<()> {
                 context.show_progress_bar();
             }
             let resolution = resolve_dependencies(&context, ResolveMode::Default, false);
-            let tree = tree(&context, &resolution.found, &resolution.failed);
+            let tree = tree(
+                &context,
+                &resolution.found,
+                &resolution.failed,
+                invert.as_deref(),
+            );
 
             if output_format.is_json() {
                 println!(

--- a/tests/cli_tree_cycle.rs
+++ b/tests/cli_tree_cycle.rs
@@ -101,6 +101,63 @@ fn tree_dedupes_diamond_dependencies() {
 }
 
 #[test]
+fn tree_invert_shows_dependents_of_target() {
+    let (project_dir, cache_dir) = diamond_project();
+    let config_path = project_dir.path().join("rproject.toml");
+
+    let mut cmd = cargo::cargo_bin_cmd!();
+    cmd.env("RV_CACHE_DIR", cache_dir.path()).args([
+        "--config-file",
+        config_path.to_str().unwrap(),
+        "tree",
+        "--hide-system-deps",
+        "--r-version",
+        "99.0",
+        "--invert",
+        "e",
+    ]);
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    insta::assert_snapshot!("diamond_invert_stdout", stdout);
+}
+
+#[test]
+fn tree_invert_errors_on_unknown_package() {
+    let (project_dir, cache_dir) = diamond_project();
+    let config_path = project_dir.path().join("rproject.toml");
+
+    let mut cmd = cargo::cargo_bin_cmd!();
+    cmd.env("RV_CACHE_DIR", cache_dir.path()).args([
+        "--config-file",
+        config_path.to_str().unwrap(),
+        "tree",
+        "--hide-system-deps",
+        "--r-version",
+        "99.0",
+        "--invert",
+        "nope",
+    ]);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected failure, stdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Package `nope` is not in the resolved dependency tree")
+    );
+}
+
+#[test]
 fn tree_handles_self_cycle_from_suggests() {
     let project_dir = TempDir::new().unwrap();
     let cache_dir = TempDir::new().unwrap();

--- a/tests/snapshots/cli_tree_cycle__diamond_invert_stdout.snap
+++ b/tests/snapshots/cli_tree_cycle__diamond_invert_stdout.snap
@@ -1,0 +1,12 @@
+---
+source: tests/cli_tree_cycle.rs
+expression: stdout
+---
+▶ e [version: 1.0.0, source: https://diamond.test/repo, type: source]
+└─ d [version: 1.0.0, source: https://diamond.test/repo, type: source]
+  ├─ b [version: 1.0.0, source: https://diamond.test/repo, type: source]
+  │ └─ a [version: 1.0.0, source: https://diamond.test/repo, type: source]
+  └─ c [version: 1.0.0, source: https://diamond.test/repo, type: source]
+    └─ a [version: 1.0.0, source: https://diamond.test/repo, type: source] (*)
+
+(*) dependency already shown above


### PR DESCRIPTION
…t package

I had an issue with a broken binary of data.table in my package, but I wasn't sure where it was coming from. `rv tree` can help, but I wanted a `--package data.table` flag to filter the tree to show me how it was being introduced. This PR adds that functionality

```
mattsmith@Mac reportifyr % rv tree | wc
    1454   15038  156127
mattsmith@Mac reportifyr % rv tree --package data.table
▶ reportifyr [ignored]
└─ flextable [version: 0.9.9, source: https://packagemanager.posit.co/cran/latest, type: source]
  └─ data.table [version: 1.17.8, source: https://packagemanager.posit.co/cran/latest, type: binary]
mattsmith@Mac reportifyr % rv tree --package systemfonts
▶ devtools [version: 2.4.5, source: https://packagemanager.posit.co/cran/latest, type: binary]
└─ pkgdown [version: 2.1.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
  └─ ragg [version: 1.4.0, source: https://packagemanager.posit.co/cran/latest, type: binary]
    ├─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
    └─ textshaping [version: 1.0.1, source: https://packagemanager.posit.co/cran/latest, type: binary]
      └─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]

▶ reportifyr [ignored]
├─ flextable [version: 0.9.9, source: https://packagemanager.posit.co/cran/latest, type: source]
│ ├─ ragg [version: 1.4.0, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │ ├─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │ └─ textshaping [version: 1.0.1, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │   └─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ ├─ officer [version: 0.6.10, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │ └─ ragg [version: 1.4.0, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │   ├─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │   └─ textshaping [version: 1.0.1, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ │     └─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
│ └─ gdtools [version: 0.4.2, source: https://packagemanager.posit.co/cran/latest, type: source]
│   └─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
└─ officer [version: 0.6.10, source: https://packagemanager.posit.co/cran/latest, type: binary]
  └─ ragg [version: 1.4.0, source: https://packagemanager.posit.co/cran/latest, type: binary]
    ├─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
    └─ textshaping [version: 1.0.1, source: https://packagemanager.posit.co/cran/latest, type: binary]
      └─ systemfonts [version: 1.2.3, source: https://packagemanager.posit.co/cran/latest, type: binary]
```