### PR TITLE
Add Validation test cases using the test suite

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,7 @@ pub enum MigrateSubcommand {
         /// Include the patch in the R version
         strict_r_version: bool,
         /// Turn off rv access through .rv R environment
+        #[clap(long)]
         no_r_environment: bool,
     },
 }

--- a/tests/input/rv-val-001.toml
+++ b/tests/input/rv-val-001.toml
@@ -1,0 +1,11 @@
+[project]
+name = "rv-val-001"
+r_version = "4.4"
+
+repositories = [
+	{alias = "ppm", url = "https://packagemanager.posit.co/cran/latest"}
+]
+
+dependencies = [
+
+]

--- a/tests/input/rv-val-002.toml
+++ b/tests/input/rv-val-002.toml
@@ -1,0 +1,11 @@
+[project]
+name = "rv-val-002"
+r_version = "4.4"
+
+repositories = [
+	{alias = "ppm", url = "https://packagemanager.posit.co/cran/latest"}
+]
+
+dependencies = [
+
+]

--- a/tests/input/workflows/rv-val-001.yml
+++ b/tests/input/workflows/rv-val-001.yml
@@ -1,0 +1,141 @@
+project-dir: rv-val-001
+config: rv-val-001.toml
+
+test:
+  steps:
+  - name: "Start R"
+    run: "R"
+    thread: r
+  
+  - name: "Create Empty Rprofile"
+    run: |
+      file.create('.Rprofile')
+      writeLines('options("repos" = c("PPM" = "https://packagemanager.posit.co/cran/latest"))', ".Rprofile")
+    thread: r
+
+  - name: "Initialize project using rv"
+    run: "rv init"
+    thread: rv
+    assert: 
+      contains: 
+       - "rv project successfully initialized at ."
+
+  - name: "Install packages"
+    run: "rv add dplyr ggplot2 tidyr"
+    thread: rv
+    insta: snapshots/rv-val-001-install.snap
+
+  - name: "Manually add package readr to .toml"
+    run: |
+      # Read the TOML file
+      toml_content <- readLines("rproject.toml")
+      
+      # Find the dependencies section
+      dep_start <- grep("^dependencies = \\[$", toml_content)
+      dep_end <- grep("^\\]$", toml_content)
+      
+      # Find the correct closing bracket for dependencies
+      # (the first ] after the dependencies = [ line)
+      dep_close <- dep_end[dep_end > dep_start][1]
+      
+      # Check if dependencies array is empty or has items
+      if (dep_close == dep_start + 1) {
+          # Empty dependencies array, add readr as first item
+          new_content <- c(
+              toml_content[1:dep_start],
+              '\t"readr",',
+              toml_content[dep_close:length(toml_content)]
+          )
+      } else {
+          # Has existing dependencies, add readr to the end
+          new_content <- c(
+              toml_content[1:(dep_close - 1)],
+              '\t"readr",',
+              toml_content[dep_close:length(toml_content)]
+          )
+      }
+      
+      # Write back to file
+      writeLines(new_content, "rproject.toml")
+      
+      # Print Updated File
+      cat(paste(readLines("rproject.toml"), collapse = "\n"))
+      cat("\n")
+    thread: r
+    assert:
+      contains: '"readr",'
+
+
+  - name: "Preview Packages"
+    run: "rv plan"
+    thread: rv
+    assert:
+      contains: 
+      - "bit"
+      - "bit64"
+      - "clipr"
+      - "crayon"
+      - "hms"
+      - "prettyunits"
+      - "progress"
+      - "readr"
+      - "tzdb"
+      - "vroom"
+
+  - name: "Sync packages"
+    run: "rv sync"
+    thread: rv
+    assert:
+      contains: "+ readr"
+
+  - name: "Check library path"
+    run: "rv library"
+    thread: rv
+    assert:
+      contains: "rv/library/4.4/arm64"
+
+  - name: "Project summary"
+    run: "rv summary"
+    thread: rv
+    assert:
+      contains:
+        - "Library: rv/library/4.4/arm64"
+        - "R Version: 4.4"
+        - "ppm (https://packagemanager.posit.co/cran/latest)"
+
+  - name: "Project Info"
+    run: "rv info --library --r-version --repositories"
+    thread: rv
+    assert:
+      contains:
+        - "library: rv/library/4.4/arm64"
+        - "r-version: 4.4"
+        - "repositories: (ppm, https://packagemanager.posit.co/cran/latest)"
+
+  - name: "Activate project"
+    run: "rv activate -c ./rproject.toml"
+    thread: rv
+    assert:
+      contains: "rv activated"
+
+  - name: "Load Installed packages"
+    run: |
+      .libPaths()
+      library(dplyr)
+      library(ggplot2)
+      library(tidyr)
+      library(readr)
+    thread: r
+    assert:
+      contains: 
+        - "library"
+        - "dplyr"
+        - "ggplot2"
+        - "tidyr"
+        - "readr"
+
+  - name: "Deactivate project"
+    run: "rv deactivate -c ./rproject.toml"
+    thread: rv
+    assert:
+      contains: "rv deactivated"

--- a/tests/input/workflows/rv-val-002.yml
+++ b/tests/input/workflows/rv-val-002.yml
@@ -1,0 +1,72 @@
+project-dir: rv-val-002
+config: rv-val-002.toml
+
+test:
+  steps:
+  - name: "Start R"
+    run: "R"
+    thread: r
+  - name: "Create sample renv project"
+    run: |
+      # Create a realistic renv.lock file manually
+      renv_lock_content <- '{
+        "R": {
+          "Version": "4.4",
+          "Repositories": [
+            {
+              "Name": "CRAN",
+              "URL": "https://cran.rstudio.com"
+            }
+          ]
+        },
+        "Packages": {
+          "dplyr": {
+            "Package": "dplyr",
+            "Version": "1.1.4",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Requirements": [
+              "R", "cli", "glue", "lifecycle", "magrittr", "rlang", "tibble", "tidyselect", "vctrs"
+            ]
+          },
+          "ggplot2": {
+            "Package": "ggplot2", 
+            "Version": "3.5.2",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Requirements": [
+              "R", "cli", "glue", "gtable", "isoband", "lifecycle", "rlang", "scales", "tibble", "vctrs", "withr"
+            ]
+          },
+          "jsonlite": {
+            "Package": "jsonlite",
+            "Version": "2.0.0",
+            "Source": "Repository", 
+            "Repository": "CRAN",
+            "Requirements": [
+              "R", "methods"
+            ]
+          }
+        }
+      }'
+      
+      # Write the renv.lock file
+      writeLines(renv_lock_content, "renv.lock")
+      
+      # Create basic .Rprofile for renv
+      writeLines("source(\"renv/activate.R\")", ".Rprofile")
+      
+      # Verify files were created
+      cat("Created files:", paste(list.files("."), collapse=", "), "\n")
+      cat("renv.lock exists:", file.exists("renv.lock"), "\n")
+    thread: r
+    assert:
+      contains:
+        - "renv.lock exists: TRUE"
+
+  - name: "Migrate renv project using rv"  
+    run: "rv migrate renv"
+    thread: rv
+    assert: 
+      contains: 
+       - "renv.lock was successfully migrated to rproject.toml" 

--- a/tests/input/workflows/rv-val-003.yml
+++ b/tests/input/workflows/rv-val-003.yml
@@ -1,0 +1,85 @@
+project-dir: rv-val-003
+config: rv-val-002.toml
+
+# This workflow tried to test renv migration "the real way" but ran into multiple issues.
+# Kept for reference on why the simple approach (rv-val-002) is better.
+#
+# What went wrong:
+# 1. renv prompts for consent even with consent options set ✅ Fixed with prompt=FALSE
+# 2. Framework timeout bug: treats timeouts as failures even when operations finish fast!
+#    (renv completes in 24ms, framework waits 5s, then fails the test anyway)
+# 3. File visibility: rv can't find renv-generated files but finds manually created ones
+#    (both use same thread structure, so not thread isolation - something about renv vs manual)
+#
+# Why rv-val-002 works instead:
+# - Creates renv.lock manually with writeLines() - rv finds it fine
+# - Same thread structure as this workflow, just different file creation method  
+
+test:
+  steps:
+  - name: "Start R"
+    run: "R"
+    thread: r
+    timeout: 3
+  - name: "Initialize renv project"
+    run: |
+      # Provide consent for renv operations (avoid interactive prompts)
+      options(renv.consent = TRUE)
+      options(renv.interactive = FALSE)
+      
+      # Initialize renv project (creates renv/ folder and .Rprofile)  
+      renv::init(bare = TRUE, restart = FALSE)
+      
+      # Verify initialization worked
+      cat("renv initialized successfully\n")
+      cat("Files created:", paste(list.files("."), collapse=", "), "\n")
+    thread: r
+    assert:
+      contains:
+        - "renv initialized successfully"
+
+  - name: "Install packages and create lockfile"
+    run: |
+      # Install some common packages (force yes to all prompts)
+      renv::install(c("dplyr", "ggplot2", "jsonlite"), prompt = FALSE)
+      
+      # Create snapshot (this generates the renv.lock file)  
+      renv::snapshot(prompt = FALSE)
+      
+      cat("Package installation and snapshot completed\n")
+    thread: r
+    assert:
+      contains:
+        - "Package installation and snapshot completed"
+
+  - name: "Verify renv.lock file is ready"
+    run: |
+      # Final verification that renv.lock exists and is readable
+      if (!file.exists("renv.lock")) {
+        stop("FATAL: renv.lock does not exist!")
+      }
+      
+      # Check if we can read it
+      content <- tryCatch({
+        readLines("renv.lock", n = 10)
+      }, error = function(e) {
+        stop("FATAL: Cannot read renv.lock: ", e$message)
+      })
+      
+      cat("✓ renv.lock verification successful\n")
+      cat("✓ File size:", file.size("renv.lock"), "bytes\n")
+      cat("✓ Can read file contents\n")
+      cat("✓ First line:", content[1], "\n")
+    thread: r
+    assert:
+      contains:
+        - "✓ renv.lock verification successful"
+        - "✓ File size:"
+        - "✓ Can read file contents"
+
+  - name: "Migrate renv project using rv"  
+    run: "rv migrate renv"
+    thread: rv
+    assert: 
+      contains: 
+       - "renv.lock was successfully migrated to rproject.toml"

--- a/tests/snapshots/r_integration__snapshots__rv-val-001-install.snap.snap
+++ b/tests/snapshots/r_integration__snapshots__rv-val-001-install.snap.snap
@@ -1,0 +1,32 @@
+---
+source: tests/r_integration.rs
+expression: filtered_output
+---
++ cli (3.6.5, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ cpp11 (0.5.2, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ dplyr (1.1.4, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ farver (2.1.2, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ generics (0.1.4, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ ggplot2 (3.5.2, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ glue (1.8.0, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ gtable (0.3.6, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ isoband (0.2.7, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ labeling (0.4.3, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ lifecycle (1.0.4, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ magrittr (2.0.3, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ pillar (1.11.0, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ pkgconfig (2.0.3, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ purrr (1.1.0, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ R6 (2.6.1, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ RColorBrewer (1.1-3, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ rlang (1.1.6, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ scales (1.4.0, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ stringi (1.8.7, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ stringr (1.5.1, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ tibble (3.3.0, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ tidyr (1.3.1, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ tidyselect (1.2.1, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ utf8 (1.2.6, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ vctrs (0.6.5, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ viridisLite (0.4.2, binary from https://packagemanager.posit.co/cran/latest) in Xms
++ withr (3.0.2, binary from https://packagemanager.posit.co/cran/latest) in Xms


### PR DESCRIPTION
Adding Tests :
- rv-val-001: Project Creation and Package Management Workflow
- rv-val-002: renv Migration Procedure (using manually created renv)
- rv-val-003: renv Migration Procedure (attempt to use renv lock from project init from R thread) // Need help with this one
   - Issue I get is that the renv file created is not found while running migrate
   - Can discard and use manually created as in 002
   
In the main.rs,
-  #[clap(long)] was added as a vibe coded fix, error surfaced during `rv migrate`


