### PR TITLE
update not found DESCRIPTION file error for git deps

### DIFF
--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -263,7 +263,7 @@ impl GitRepository {
 
         Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "Not found",
+            "DESCRIPTION file not found",
         ))
     }
 


### PR DESCRIPTION
Error before:
```
Failed to resolve all dependencies
    shiny [listed in rproject.toml]: Could not fetch repository https://github.com/rstudio/shiny.git (ref: Branch("gh-pages")) Not found
```

This error implies to most users that the repository could not be fetched because the ref/repo is the issue, not that it is not a proper package

Error after:
```
Failed to resolve all dependencies
    shiny [listed in rproject.toml]: Could not fetch repository https://github.com/rstudio/shiny.git (ref: Branch("gh-pages")) DESCRIPTION file not found
```