### PR TITLE
activate script update

### DIFF
--- a/.github/scripts/e2e.py
+++ b/.github/scripts/e2e.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import subprocess
+import re
 
 INIT_FOLDER = "init"
 CONFIG_FILE = "rproject.toml"
@@ -28,51 +28,34 @@ def run_r_script(script = str):
     command = ["Rscript", "-e", script]
     return run_cmd(command)
 
-def add_repo(file_path, repo = str):
+def edit_r_version(file_path: str, r_version: str) -> None:
     with open(file_path, "r") as f:
-        lines = f.readlines()
+        content = f.read()
 
-    new_lines = []
-    in_repos = False
-    repo_inserted = False
-
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-
-        if not in_repos and stripped.startswith("repositories") and "[" in stripped:
-            in_repos = True
-            new_lines.append(line)
-            continue
-
-        if in_repos and not repo_inserted:
-            if stripped.startswith("]"):
-                new_lines.append(f"    {repo},\n")
-                new_lines.append(line)
-                repo_inserted = True
-                in_repos = False
-                continue
-            else:
-                # Insert the new repo before the first existing entry
-                new_lines.append(f"    {repo},\n")
-                new_lines.append(line)
-                repo_inserted = True
-                continue
-
-        new_lines.append(line)
+    # Replace the first r_version value anywhere in the file
+    updated = re.sub(
+        r'(\br_version\s*=\s*")[^"]+(")',
+        rf'\g<1>{r_version}\g<2>',
+        content,
+        count=1,
+    )
 
     with open(file_path, "w") as f:
-        f.writelines(new_lines)
+        f.write(updated)
         
-def check_r_profile():
-    if f"{INIT_FOLDER}/rv/library" not in run_r_script(".libPaths()"):
+def check_r_profile(r_versions_match = bool):
+    if r_versions_match:
+        expected_lib_elem = f"{INIT_FOLDER}/rv/library"
+    else:
+        expected_lib_elem = "__rv_R_mismatch"
+        
+    if expected_lib_elem not in run_r_script(".libPaths()"):
         print(f".libPaths not set correctly upon init")
         exit(1)
-    
+
     if "rv-test-repo/repo2" not in run_r_script("getOption('repos')"):
         print(f"repos not set correctly upon init")
         exit(1)
-        
-    
 
 def run_test():
     os.environ["PATH"] = f"{os.path.abspath('./target/release')}:{os.environ.get('PATH', '')}"
@@ -82,9 +65,9 @@ def run_test():
     
     
     try: 
-        add_repo(CONFIG_FILE, RV_REPO_2)
+        run_rv_cmd("configure", ["repository", "add", "repo2", "--url", "https://a2-ai.github.io/rv-test-repo/repo2"])
         run_r_script("source('.Rprofile')")
-        check_r_profile()
+        check_r_profile(True)
         run_r_script(".rv$add('rv.git.pkgA', dry_run=TRUE)")
         summary = run_rv_cmd("summary", [])
         if "Installed: 0/0" not in summary:
@@ -96,13 +79,19 @@ def run_test():
             print(f"rv add --no-sync did not behave as expected")
             
         run_rv_cmd("add", ["rv.git.pkgA"])
-        add_repo(CONFIG_FILE, RV_REPO_1)
+        run_rv_cmd("configure", ["repository", "add", "repo1", "--url", "https://a2-ai.github.io/rv-test-repo/repo1", "--first"])
         res = run_rv_cmd("sync", [])
         if "Nothing to do" not in res:
             print("Adding repo caused re-sync")
+            exit(1)
         res = run_rv_cmd("upgrade", [])
         if "- rv.git.pkgA" not in res or "+ rv.git.pkgA (0.0.5" not in res or "from https://a2-ai.github.io/rv-test-repo/repo1)" not in res:
             print("Upgrade did not behave as expected")
+            exit(1)
+        
+        edit_r_version(CONFIG_FILE, "4.3")
+        run_r_script("source('.Rprofile')")
+        check_r_profile(False)
     finally:
         os.chdir(original_dir)
 

--- a/.github/scripts/e2e.py
+++ b/.github/scripts/e2e.py
@@ -68,7 +68,6 @@ def run_test():
     
     try: 
         run_rv_cmd("configure", ["repository", "add", "repo2", "--url", "https://a2-ai.github.io/rv-test-repo/repo2"])
-        run_r_script("source('.Rprofile')")
         check_r_profile(True)
         run_r_script(".rv$add('rv.git.pkgA', dry_run=TRUE)")
         summary = run_rv_cmd("summary", [])
@@ -100,7 +99,6 @@ def run_test():
                 exit(1)        
          
         edit_r_version(CONFIG_FILE, "4.3")
-        run_r_script("source('.Rprofile')")
         check_r_profile(False)
 
     finally:

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -86,8 +86,7 @@ pub(crate) const ACTIVATE_FILE_TEMPLATE: &str = r#"local({%global wd content%
 		sub(paste0("^", prefix, ":\\s*"), "", line)
 	}
 
-	rv_lib <- normalizePath(get_val("library"), mustWork = FALSE)
-	rv_r_ver <- get_val("r-version")
+	# Set repos option
 	repo_str <- get_val("repositories")
 
 	repo_parts <- strsplit(repo_str, "), ", fixed = TRUE)[[1]]
@@ -102,21 +101,41 @@ pub(crate) const ACTIVATE_FILE_TEMPLATE: &str = r#"local({%global wd content%
 		repo_urls[i] <- trimws(parts[2])
 	}
 	names(repo_urls) <- repo_names
+	options(repos = repo_urls)
+
+	# Check R version and set library
+	rv_r_ver <- get_val("r-version")
+	sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
+	r_match <- grepl(paste0("^", rv_r_ver), sys_r)
+
+	rv_lib <- if (r_match) {
+		normalizePath(get_val("library"), mustWork = FALSE)
+	} else {
+		message(sprintf(
+			"WARNING: R version specified in config (%s) does not match session version (%s).
+rv library will not be activated until the issue is resolved. Entering safe mode...
+			",
+			rv_r_ver,
+			sys_r
+		))
+		file.path(tempdir(), "__rv_R_mismatch")
+	}
 
 	if (!dir.exists(rv_lib)) {
-		message("creating rv library: ", rv_lib)
+		if (r_match) {
+			message("creating rv library: ", rv_lib, "\n")
+		} else {
+			message("creating temporary library: ", rv_lib, "\n")
+		}
 		dir.create(rv_lib, recursive = TRUE)
 	}
 
 	.libPaths(rv_lib, include.site = FALSE)
-	options(repos = repo_urls)
+	Sys.setenv("R_LIBS_USER" = .libPaths()[1])
+	Sys.setenv("R_LIBS_SITE" = .libPaths()[1])
 
+	# Results
 	if (interactive()) {
-		message(
-			"rv libpaths active!\nlibrary paths: \n",
-			paste0("  ", .libPaths(), collapse = "\n"),
-			"\n"
-		)
 		message(
 			"rv repositories active!\nrepositories: \n",
 			paste0(
@@ -125,16 +144,17 @@ pub(crate) const ACTIVATE_FILE_TEMPLATE: &str = r#"local({%global wd content%
 				": ",
 				getOption("repos"),
 				collapse = "\n"
-			)
+			),
+			"\n"
 		)
-		sys_r <- sprintf("%s.%s", R.version$major, R.version$minor)
-		if (!grepl(paste0("^", rv_r_ver), sys_r)) {
-			message(sprintf(
-				"\nWARNING: R version specified in config (%s) does not match session version (%s)",
-				rv_r_ver,
-				sys_r
-			))
-		}
+		message(
+			ifelse(
+				r_match,
+				"rv libpaths active!\nlibrary paths: \n",
+				"rv libpaths are not active due to R version mismatch. Using temp directory: \n"
+			),
+			paste0("  ", .libPaths(), collapse = "\n")
+		)
 	}
 })
 "#;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -131,8 +131,8 @@ rv library will not be activated until the issue is resolved. Entering safe mode
 	}
 
 	.libPaths(rv_lib, include.site = FALSE)
-	Sys.setenv("R_LIBS_USER" = .libPaths()[1])
-	Sys.setenv("R_LIBS_SITE" = .libPaths()[1])
+	Sys.setenv("R_LIBS_USER" = rv_lib)
+	Sys.setenv("R_LIBS_SITE" = rv_lib)
 
 	# Results
 	if (interactive()) {
@@ -148,11 +148,11 @@ rv library will not be activated until the issue is resolved. Entering safe mode
 			"\n"
 		)
 		message(
-			ifelse(
-				r_match,
-				"rv libpaths active!\nlibrary paths: \n",
+			if (r_match) {
+				"rv libpaths active!\nlibrary paths: \n"
+			} else {
 				"rv libpaths are not active due to R version mismatch. Using temp directory: \n"
-			),
+			},
 			paste0("  ", .libPaths(), collapse = "\n")
 		)
 	}


### PR DESCRIPTION
This PR addresses:
1. When the R version in the config and the active R session do match, we currently only warn the user, but that can leave them in a "dangerous" situation. Instead, we will warn the user and set their libpaths to a temp directory. `rv` will still work as normal, but the packages will not be accessible in the R session until the version mismatched is resolved
2. Setting the `R_LIBS_USER` and `R_LIBS_SITE` to be the `rv` library for further isolation and control