### PR TITLE
Re-org CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Formats the toml configuration file while preserving comments and spacing
     Fmt {
         // add a --check flag to check formatting without changing the file
         #[clap(long)]


### PR DESCRIPTION
Re organize the cli to put common commands near each other. This organization also is similar to the website organization. There is no content change within this PR except adding a description to the fmt command

```
Commands:
  init        Creates a new rv project
  migrate     Migrate renv to rv
  sync        Replaces the library with exactly what is in the lock file
  add         Add simple packages to the project and sync
  upgrade     Upgrade packages to the latest versions available
  plan        Dry run of what sync would do
  summary     Provide a summary about the project status
  configure   Configure project settings
  fmt         Formats the toml configuration file while preserving comments and spacing
  tree        Shows the project packages in tree format
  library     Returns the path for the library for the current project/system in UNIX format, even on Windows
  cache       Gives information about where the cache is for that project
  info        Simple information about the project
  sysdeps     List the system dependencies needed by the dependency tree. This is currently only supported on Ubuntu/Debian, it will return an empty result anywhere else
  activate    Activate a previously initialized rv project
  deactivate  Deactivate an rv project
  help        Print this message or the help of the given subcommand(s)
```

closes: #277