### PR TITLE
Add action for automatically updating the homebrew formula

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Update Homebrew formula
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           brew tap A2-ai/homebrew-tap
           brew bump-formula-pr --no-browse --no-audit \


### PR DESCRIPTION
Hi `rv` team,

I noticed that the `rv` Homebrew tap has fallen behind a bit. The [repo](https://github.com/A2-ai/homebrew-tap) currently shows 0.13.2 as the latest release, while 0.15.0 has just been released on GH.

While it would be nice to manually update the formula for now, this PR adds a GH Action to ease future releases by automatically updating the `rv.rb` formula in the `A2-ai/homebrew-tap` repository whenever new releases are published. (Behind the scenes, it uses `brew bump-formula-pr` to handle everything.)

**EDIT:** My description above wasn't as clear as it could have been. What will happen is that, after you issue a new `rv` release on GH, this Action will automatically trigger a corresponding PR at the `A2-ai/homebrew-tap` sister repo with the updated formula. So you'll still need to approve it, but that's a small lift.

It's tricky to test that everything is working as expected on my end---since I don't have the requisite repo permissions---but I should think the risk is low. (All that will happen is the automatic update won't go through.) Regardless, it does require some one-time setup:

1. Create a GitHub Personal Access Token at https://github.com/settings/tokens/new
   - Select scopes: `public_repo` and `workflow`
2. Add it as a repository secret in `A2-ai/rv`:
   - Go to Settings → Secrets and variables → Actions → New repository secret
   - Name: `TOKEN`
   - Value: Your personal access token
3. Ensure the token owner has write access to `A2-ai/homebrew-tap`

After merging and setting up the token, the next release should (hopefully!) automatically trigger the workflow. You can also test it sooner than that by creating a pre-release.