### PR TITLE
Fix repo dectection on RedHat Enterprise Linux

### DIFF
--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -86,7 +86,7 @@ impl SystemInfo {
             Type::CentOS => OsType::Linux("centos"),
             Type::AlmaLinux => OsType::Linux("almalinux"),
             Type::openSUSE => OsType::Linux("opensuse"),
-            Type::Redhat => OsType::Linux("redhat"),
+            Type::Redhat | Type::RedHatEnterprise => OsType::Linux("redhat"),
             Type::RockyLinux => OsType::Linux("rocky"),
             Type::SUSE => OsType::Linux("suse"),
             Type::Gentoo => OsType::Linux("gentoo"),


### PR DESCRIPTION
* Closes #352

For some versions of RedHat os_info presents it as RedHat Enterprise

<img width="1063" height="505" alt="image" src="https://github.com/user-attachments/assets/f86d19cd-2c6c-494c-9ae8-6d55dc56e8c2" />
