### PR TITLE
Fixes compilation for monorepo like R packages from Git

### DIFF
--- a/src/sync/sources/git.rs
+++ b/src/sync/sources/git.rs
@@ -35,7 +35,7 @@ pub(crate) fn install_package(
             git_exec.clone(),
         )?;
         // If we have a directory, don't forget to set it before building it
-        let source_path = match &pkg.source {
+        let (source_path, sub_dir) = match &pkg.source {
             Source::Git {
                 directory: Some(dir),
                 ..
@@ -43,12 +43,13 @@ pub(crate) fn install_package(
             | Source::RUniverse {
                 directory: Some(dir),
                 ..
-            } => pkg_paths.source.join(dir),
-            _ => pkg_paths.source,
+            } => (pkg_paths.source, Some(dir)),
+            _ => (pkg_paths.source, None),
         };
 
         let output = r_cmd.install(
             &source_path,
+            sub_dir.as_deref(),
             library_dirs,
             &pkg_paths.binary,
             cancellation,

--- a/src/sync/sources/local.rs
+++ b/src/sync/sources/local.rs
@@ -54,6 +54,7 @@ pub(crate) fn install_package(
         log::debug!("Building the local package in {}", actual_path.display());
         let output = r_cmd.install(
             &actual_path,
+            Option::<&Path>::None,
             library_dirs,
             library_dirs.first().unwrap(),
             cancellation,

--- a/src/sync/sources/repositories.rs
+++ b/src/sync/sources/repositories.rs
@@ -31,6 +31,7 @@ pub(crate) fn install_package(
         log::debug!("Compiling package from {}", source_path.display());
         match r_cmd.install(
             &source_path,
+            Option::<&Path>::None,
             library_dirs,
             &pkg_paths.binary,
             cancellation.clone(),

--- a/src/sync/sources/url.rs
+++ b/src/sync/sources/url.rs
@@ -37,6 +37,7 @@ pub(crate) fn install_package(
         );
         let output = r_cmd.install(
             &download_path,
+            Option::<&Path>::None,
             library_dirs,
             &pkg_paths.binary,
             cancellation,


### PR DESCRIPTION
* Closes #354 

---

Some R packages use a `bootstrap.R` file that get's called right before building the source or binary packages. This is helpful for vendoring sources and working with monorepos.

Many times this `bootstrap.R` copies files from parent directories, examples of this include apache/arrow (https://github.com/apache/arrow/blob/main/r/bootstrap.R), sedonabd, treesitter.r, and many more. We use this pattern a lot at ixpantia.

Installing from Git with packages like remotes or renv respect this and keep the whole repo on disk in case this file needs to be called or there are any dependencies on parent directories.

Currently rv copies only the directory where the R package is found, not the whole repo when installing.

https://github.com/A2-ai/rv/blob/b9f18c24904122079e7e73ba416eaf98a5814a25/src/sync/sources/git.rs#L46

This causes files like `boostrap.R` to fail, since many times they copy files from `../` directories.

If I try to run `rv sync -vvvv` on a rproject.toml file specifying a Git dependency from a subdirectory that depends on other files in the repo it will fail.

The fix in this pr changes one thing. It copies the entire repo instead of just the subdirectory and passes the subdirectoy as an additional argument. This argument is the used to recreate the path and install from there. This way rv keeps all the files R CMD install / build needs to properly build the package. 

```
[project]
name = "rv_bug"
r_version = "4.5"

repositories = [
    {alias = "CRAN", url = "https://cloud.r-project.org/"},
]

dependencies = [
    { name = "sedonadb", git = "https://github.com/apache/sedona-db", branch = "main", directory = "r/sedonadb" },
]
```

```
[2025-11-11T13:58:41Z DEBUG rv::r_cmd] R found on the path: 4.5.1
[2025-11-11T13:58:41Z DEBUG rv::git::local] Opening git repository at /Users/andres/.cache/rv/git/8b348820cf
[2025-11-11T13:58:41Z DEBUG rv::git::local] Fetching https://github.com/apache/sedona-db with reference Branch("main")
[2025-11-11T13:58:42Z DEBUG rv::git::local] Getting description file content of repo https://github.com/apache/sedona-db at Branch("main") in /Users/andres/.cache/rv/git/8b348820cf
[2025-11-11T13:58:42Z DEBUG rv::git::local] No need to checkout 0f0ba4d651e07d7807fc00cfe0608030b7359faf, it's already checked out
[2025-11-11T13:58:42Z DEBUG rv::resolver::sat] Solving dependencies for 4 packages and 2 version requirements
[2025-11-11T13:58:42Z DEBUG rv::resolver::sat] Starting SAT solving
[2025-11-11T13:58:42Z INFO  rv::resolver::sat] SAT solving completed in 4.708µs, found 4 packages
[2025-11-11T13:58:42Z DEBUG rv::sync::handler] Packages with files loaded (via lsof): {}
[2025-11-11T13:58:42Z DEBUG rv::sync::handler] Installing sedonadb (source) on worker 1
[2025-11-11T13:58:42Z DEBUG rv::git::local] Opening git repository at /Users/andres/.cache/rv/git/8b348820cf
[2025-11-11T13:58:42Z DEBUG rv::git::local] Disabling sparse checkout in /Users/andres/.cache/rv/git/8b348820cf
[2025-11-11T13:58:42Z DEBUG rv::git::local] No need to fetch https://github.com/apache/sedona-db, reference Commit("0f0ba4d651e07d7807fc00cfe0608030b7359faf") is already found locally
[2025-11-11T13:58:42Z DEBUG rv::git::local] No need to checkout 0f0ba4d651e07d7807fc00cfe0608030b7359faf, it's already checked out
[2025-11-11T13:58:42Z DEBUG rv::r_cmd] Compiling /Users/andres/.cache/rv/git/8b348820cf/r/sedonadb with env vars: R_LIBS_SITE=/Users/andres/Documents/code/rv/rv_bug/rv/library/4.5/arm64/__rv__staging:/Users/andres/Documents/code/rv/rv_bug/rv/library/4.5/arm64 R_LIBS_USER=/Users/andres/Documents/code/rv/rv_bug/rv/library/4.5/arm64/__rv__staging:/Users/andres/Documents/code/rv/rv_bug/rv/library/4.5/arm64 _R_SHLIB_STRIP_=true
[2025-11-11T13:58:48Z INFO  rv::cli::sync] Synced dependencies in 6112ms
Failed to install dependencies.
    Failed to install sedonadb:
        Failed to install R package: Installation failed: * installing *source* package ‘sedonadb’ ...
** this is package ‘sedonadb’ version ‘0.1.0.9000’
** using staged installation
Found GEOS pkg-config libs!
using Rust package manager: 'cargo 1.90.0 (840b83a10 2025-07-30)'
using Rust compiler: 'rustc 1.90.0 (1159e78c4 2025-09-14)'
** libs
using C compiler: ‘Apple clang version 17.0.0 (clang-1700.0.13.5)’
using SDK: ‘’
clang -arch arm64 -std=gnu2x -I"/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/include" -DNDEBUG   -I/opt/R/arm64/include    -fPIC  -falign-functions=64 -Wall -g -O2  -c init.c -o init.o
# In some environments, ~/.cargo/bin might not be included in PATH, so we need
# to set it here to ensure cargo can be invoked. It is appended to PATH and
# therefore is only used if cargo is absent from the user's PATH.
export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/Users/andres/.local/bin/google-cloud-sdk/bin:/Users/andres/.local/bin:/usr/local/bin:/Users/andres/.cargo/bin:/home/andres/.juliaup/bin:/home/andres/.local/bin:/home/andres/.npm-global/bin:/home/andres/go/bin:/home/andres/bin:/home/andres/.cargo/bin:/opt/homebrew/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Applications/quarto/bin:/Users/andres/.cargo/bin" && \
	  export CC="clang -arch arm64 -std=gnu2x" && \
	  export CFLAGS="-falign-functions=64 -Wall -g -O2  -Wno-pedantic" && \
	  export AWS_LC_SYS_CMAKE_BUILDER=1 && \
	  export RUSTFLAGS="" && \
	  if [ "" != "wasm32-unknown-emscripten" ]; then \
	    cargo build --lib --profile release  --manifest-path=./rust/Cargo.toml --target-dir /private/var/folders/db/ss510s5x76qf66kcqn1jxbb40000gn/T/.tmpZD7EA9/src/rust/target; \
	  else \
	    export CARGO_PROFILE_DEV_PANIC="abort" && \
	    export CARGO_PROFILE_RELEASE_PANIC="abort" && \
	    export RUSTFLAGS=" -Zdefault-visibility=hidden" && \
	    cargo +nightly build --lib --profile release  --manifest-path=./rust/Cargo.toml --target-dir /private/var/folders/db/ss510s5x76qf66kcqn1jxbb40000gn/T/.tmpZD7EA9/src/rust/target --target  -Zbuild-std=panic_abort,std; \
	  fi
error: failed to parse manifest at `/private/var/folders/db/ss510s5x76qf66kcqn1jxbb40000gn/T/.tmpZD7EA9/src/rust/Cargo.toml`

Caused by:
  error inheriting `version` from workspace root manifest's `workspace.package.version`

Caused by:
  failed to find a workspace root
make: *** [/private/var/folders/db/ss510s5x76qf66kcqn1jxbb40000gn/T/.tmpZD7EA9/src/rust/target//release/libsedonadbr.a] Error 101
ERROR: compilation failed for package ‘sedonadb’
* removing ‘/private/var/folders/db/ss510s5x76qf66kcqn1jxbb40000gn/T/.tmp5SbDag/sedonadb’
)
```