### PR TITLE
ignoring library

### DIFF
--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -57,10 +57,15 @@ pub struct CliContext {
     // on mac/windows/arch etc
     pub system_dependencies: HashMap<String, Vec<String>>,
     pub show_progress_bar: bool,
+    pub ignore_library: bool,
 }
 
 impl CliContext {
-    pub fn new(config_file: &PathBuf, r_command_lookup: RCommandLookup) -> Result<Self> {
+    pub fn new(
+        config_file: &PathBuf,
+        r_command_lookup: RCommandLookup,
+        ignore_library: bool,
+    ) -> Result<Self> {
         let config = Config::from_file(config_file)?;
 
         // This can only be set to false if the user passed a r_version to rv plan
@@ -138,6 +143,7 @@ impl CliContext {
             show_progress_bar: false,
             builtin_packages,
             system_dependencies: HashMap::new(),
+            ignore_library,
         })
     }
 

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -82,6 +82,9 @@ impl SyncHelper {
                     handler.show_progress_bar();
                 }
                 handler.set_uses_lockfile(context.config.use_lockfile());
+                if context.ignore_library {
+                    handler.set_ignore_library();
+                }
                 handler.handle(&resolution.found, &context.r_cmd)
             }
         ) {


### PR DESCRIPTION
Adding the flag `--ignore-library` (up for renaming if desired) to `sync`, `add`, `upgrade`, `plan`, and `summary` to behave as if there is no library present.

The main motivation was to provide a way to list the _full_ dependency resolution of the config, not just the diff.  Including it for the other commands that consider the library state was simply a bonus. 

For sync commands, this removes all deps in the library and replaces them with the staging (similar to earlier versions). This may not be ideal on NFS systems, but this flag would most often be used in those scenarios when the goal is to get rid of something in the library.

Note, this was initially done using CC, but after a couple iterations (which I need to do better at committing) it was trying to overcomplicate this and make separate pathways to handle this, so this change was primarily "hand" written.