### PR TITLE
Fix Version ser/de for config

### DIFF
--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -15,7 +15,7 @@ pub use builtin::{BuiltinPackages, get_builtin_versions_from_library};
 pub use description::{parse_description_file, parse_description_file_in_folder, parse_version};
 pub use parser::parse_package_file;
 pub use remotes::PackageRemote;
-pub use version::{Operator, Version, VersionRequirement, deserialize_version};
+pub use version::{Operator, Version, VersionRequirement, deserialize_version, serialize_version};
 
 pub(crate) use remotes::parse_remote;
 

--- a/src/package/version.rs
+++ b/src/package/version.rs
@@ -146,6 +146,13 @@ where
     }
 }
 
+pub fn serialize_version<S>(version: &Version, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&version.original)
+}
+
 /// A package can require specific version for some versions.
 /// Most of the time it's using >= but there are also some
 /// >, <, <= here and there and a couple of ==


### PR DESCRIPTION
The current version serialization currently causes an issue when trying to programmatically save a rproject.toml