### PR TITLE
[likely no merge] Fix ref

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -183,7 +183,7 @@ impl Library {
 
     pub fn contains_package(&self, pkg: &ResolvedDependency) -> bool {
         if self.custom
-            || (!self.packages.contains_key(pkg.name.as_ref())
+            || (!self.packages.contains_key(&*pkg.name)
                 && !matches!(pkg.source, Source::Builtin { .. }))
         {
             return false;
@@ -194,11 +194,11 @@ impl Library {
             | Source::Url { ref sha, .. }
             | Source::RUniverse { ref sha, .. } => self
                 .non_repo_packages
-                .get(pkg.name.as_ref())
+                .get(&*pkg.name)
                 .and_then(|m| m.sha().map(|s| s == sha.as_str()))
                 .unwrap_or(false),
             Source::Local { ref sha, .. } => {
-                if let Some(metadata) = self.non_repo_packages.get(pkg.name.as_ref()) {
+                if let Some(metadata) = self.non_repo_packages.get(&*pkg.name) {
                     match metadata {
                         LocalMetadata::Mtime(local_mtime) => {
                             let current_mtime =
@@ -220,7 +220,7 @@ impl Library {
                     false
                 }
             }
-            Source::Repository { .. } => &self.packages[pkg.name.as_ref()] == pkg.version.as_ref(),
+            Source::Repository { .. } => &self.packages[&*pkg.name] == &*pkg.version,
             Source::Builtin { .. } => true,
         }
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -595,7 +595,7 @@ impl Lockfile {
 
     pub fn contains_resolved_dep(&self, dep: &ResolvedDependency) -> bool {
         self.packages.iter().any(|lock_pkg| {
-            lock_pkg.name == dep.name.as_ref() && lock_pkg.version == dep.version.as_ref().original
+            lock_pkg.name == &*dep.name && lock_pkg.version == dep.version.original
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,7 +593,7 @@ fn try_main() -> Result<()> {
             let resolved = resolve_dependencies(&context, ResolveMode::Default, true).found;
             let project_sys_deps: HashSet<_> = resolved
                 .iter()
-                .flat_map(|x| context.system_dependencies.get(x.name.as_ref()))
+                .flat_map(|x| context.system_dependencies.get(&*x.name))
                 .flatten()
                 .map(|x| x.as_str())
                 .collect();
@@ -772,7 +772,7 @@ fn try_main() -> Result<()> {
             let resolved = resolve_dependencies(&context, ResolveMode::Default, false).found;
             let project_sys_deps: HashSet<_> = resolved
                 .iter()
-                .flat_map(|x| context.system_dependencies.get(x.name.as_ref()))
+                .flat_map(|x| context.system_dependencies.get(&*x.name))
                 .flatten()
                 .map(|x| x.as_str())
                 .collect();

--- a/src/project_summary.rs
+++ b/src/project_summary.rs
@@ -270,7 +270,7 @@ impl<'a> DependencyInfo<'a> {
 
         // we keep track of the dependencies organized by their source identifier
         for r in resolved_deps {
-            lib_pkgs.remove(r.name.as_ref());
+            lib_pkgs.remove(&*r.name);
             let mut dep_sum = DependencySummary::new(r, library, repo_dbs, r_version, cache);
             // if the package was found in the library, but not in the lockfile, we consider it not locked and is missing
             if !is_in_lock(r.name.as_ref(), lockfile)

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -436,7 +436,7 @@ impl<'d> Resolver<'d> {
         &self,
         item: &QueueItem<'d>,
     ) -> Option<(ResolvedDependency<'d>, Vec<QueueItem<'d>>)> {
-        if let Some(package) = self.builtin_packages.get(item.name.as_ref()) {
+        if let Some(package) = self.builtin_packages.get(&*item.name) {
             if let Some(ref req) = item.version_requirement {
                 if req.is_satisfied(&package.version) {
                     let (resolved_dep, deps) =
@@ -501,9 +501,9 @@ impl<'d> Resolver<'d> {
             .collect();
 
         while let Some(item) = queue.pop_front() {
-            if let Some(ver_reqs) = processed.get(item.name.as_ref()) {
+            if let Some(ver_reqs) = processed.get(&*item.name) {
                 // If we have already found that dependency and it has a forced repo, skip it
-                if repo_required.contains(item.name.as_ref()) {
+                if repo_required.contains(&*item.name) {
                     continue;
                 }
 
@@ -572,7 +572,7 @@ impl<'d> Resolver<'d> {
             let can_be_overridden = item.version_requirement.is_some()
                 && prefer_repositories_for
                     .iter()
-                    .any(|s| s == item.name.as_ref());
+                    .any(|s| s == &*item.name);
 
             if let Some(ref remote) = item.remote {
                 match remote {
@@ -712,7 +712,7 @@ impl<'d> Resolver<'d> {
         }
 
         for dep in result.found.iter_mut() {
-            if let Some(args) = self.packages_env_vars.get(dep.name.as_ref()) {
+            if let Some(args) = self.packages_env_vars.get(&*dep.name) {
                 dep.env_vars = args.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
             }
         }

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -101,7 +101,7 @@ impl<'d> Resolution<'d> {
                     if names.contains(&pkg.name) {
                         continue;
                     }
-                    if let Some(version) = assignments.get(pkg.name.as_ref()) {
+                    if let Some(version) = assignments.get(&*pkg.name) {
                         if pkg.version.as_ref() == *version {
                             names.insert(&pkg.name);
                             indices.insert(i);

--- a/src/sync/build_plan.rs
+++ b/src/sync/build_plan.rs
@@ -59,11 +59,11 @@ impl<'a> BuildPlan<'a> {
             .iter()
             .find(|d| d.name == name)
             .expect("to find the dep");
-        self.installed.insert(pkg.name.as_ref());
-        self.installing.remove(pkg.name.as_ref());
+        self.installed.insert(&*pkg.name);
+        self.installing.remove(&*pkg.name);
 
         for (_, deps) in self.full_deps.iter_mut() {
-            deps.remove(pkg.name.as_ref());
+            deps.remove(&*pkg.name);
         }
     }
 

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -275,8 +275,8 @@ impl<'a> SyncHandler<'a> {
         LinkMode::link_files(
             Some(LinkMode::Copy),
             &dep.name,
-            self.context.library.path().join(dep.name.as_ref()),
-            self.context.staging_path().join(dep.name.as_ref()),
+            self.context.library.path().join(&*dep.name),
+            self.context.staging_path().join(&*dep.name),
         )?;
 
         Ok(())
@@ -630,7 +630,7 @@ impl<'a> SyncHandler<'a> {
                             }
                         }
                         let start = std::time::Instant::now();
-                        let install_result = if deps_to_copy_clone.contains(dep.name.as_ref()) {
+                        let install_result = if deps_to_copy_clone.contains(&*dep.name) {
                             self.copy_package(dep)
                         } else {
                             self.install_package(dep, r_cmd, cancellation_clone.clone())
@@ -672,7 +672,7 @@ impl<'a> SyncHandler<'a> {
                                     start.elapsed(),
                                     self.context
                                         .system_dependencies
-                                        .get(dep.name.as_ref())
+                                        .get(&*dep.name)
                                         .cloned()
                                         .unwrap_or_default(),
                                     cache_source,

--- a/src/sync/sources/git.rs
+++ b/src/sync/sources/git.rs
@@ -66,7 +66,7 @@ pub(crate) fn install_package(
         }
 
         let metadata = LocalMetadata::Sha(sha.to_owned());
-        metadata.write(local_paths.binary.join(pkg.name.as_ref()))?;
+        metadata.write(local_paths.binary.join(&*pkg.name))?;
     }
 
     // Link from global cache if available there, otherwise from local cache

--- a/src/sync/sources/local.rs
+++ b/src/sync/sources/local.rs
@@ -35,7 +35,7 @@ pub(crate) fn install_package(
         canon_path.clone()
     };
 
-    if is_binary_package(&actual_path, pkg.name.as_ref()).map_err(|err| SyncError {
+    if is_binary_package(&actual_path, &*pkg.name).map_err(|err| SyncError {
         source: crate::sync::errors::SyncErrorKind::InvalidPackage {
             path: actual_path.to_path_buf(),
             error: err.to_string(),
@@ -47,9 +47,9 @@ pub(crate) fn install_package(
         );
         LinkMode::link_files(
             Some(LinkMode::Copy),
-            pkg.name.as_ref(),
+            &*pkg.name,
             &actual_path,
-            library_dirs.first().unwrap().join(pkg.name.as_ref()),
+            library_dirs.first().unwrap().join(&*pkg.name),
         )?;
     } else {
         log::debug!("Building the local package in {}", actual_path.display());
@@ -78,7 +78,7 @@ pub(crate) fn install_package(
     } else {
         LocalMetadata::Sha(sha.unwrap())
     };
-    metadata.write(library_dirs.first().unwrap().join(pkg.name.as_ref()))?;
+    metadata.write(library_dirs.first().unwrap().join(&*pkg.name))?;
 
     Ok(())
 }

--- a/src/sync/sources/repositories.rs
+++ b/src/sync/sources/repositories.rs
@@ -27,7 +27,7 @@ pub(crate) fn install_package(
         cache.get_package_paths(&pkg.source, Some(&pkg.name), Some(&pkg.version.original));
 
     let compile_package = || -> Result<(), SyncError> {
-        let source_path = local_paths.source.join(pkg.name.as_ref());
+        let source_path = local_paths.source.join(&*pkg.name);
         log::debug!("Compiling package from {}", source_path.display());
         match r_cmd.install(
             &source_path,
@@ -54,7 +54,7 @@ pub(crate) fn install_package(
                 let _ = fs::File::create(
                     local_paths
                         .binary
-                        .join(pkg.name.as_ref())
+                        .join(&*pkg.name)
                         .join(BUILT_FROM_SOURCE_FILENAME),
                 )?;
                 Ok(())
@@ -137,8 +137,8 @@ pub(crate) fn install_package(
                     } else {
                         // Ok we download some tarball. We can't assume it's actually compiled though, it could be just
                         // source files. We have to check first whether what we have is actually binary content.
-                        let bin_path = local_paths.binary.join(pkg.name.as_ref());
-                        if !is_binary_package(&bin_path, pkg.name.as_ref()).map_err(|err| {
+                        let bin_path = local_paths.binary.join(&*pkg.name);
+                        if !is_binary_package(&bin_path, &*pkg.name).map_err(|err| {
                             SyncError {
                                 source: crate::sync::errors::SyncErrorKind::InvalidPackage {
                                     path: bin_path,

--- a/src/sync/sources/url.rs
+++ b/src/sync/sources/url.rs
@@ -19,7 +19,7 @@ pub(crate) fn install_package(
     cancellation: Arc<Cancellation>,
 ) -> Result<(), SyncError> {
     let pkg_paths = cache.get_package_paths(&pkg.source, None, None);
-    let download_path = pkg_paths.source.join(pkg.name.as_ref());
+    let download_path = pkg_paths.source.join(&*pkg.name);
 
     // If we have a binary, copy it since we don't keep cache around for binary URL packages
     if pkg.kind == PackageType::Binary {
@@ -59,7 +59,7 @@ pub(crate) fn install_package(
     }
 
     let metadata = LocalMetadata::Sha(pkg.source.sha().to_owned());
-    metadata.write(pkg_paths.binary.join(pkg.name.as_ref()))?;
+    metadata.write(pkg_paths.binary.join(&*pkg.name))?;
 
     // And then we always link the binary folder into the staging library
     LinkMode::link_files(


### PR DESCRIPTION
before this PR, when running `cargo install --all-features --path .`

get a slew of:

```
error[E0283]: type annotations needed
    --> src/library.rs:186:32
     |
 186 |             || (!self.packages.contains_key(pkg.name.as_ref())
     |                                ^^^^^^^^^^^^ ----------------- type must be known at this point
     |                                |
     |                                cannot infer type of the type parameter `Q` declared on the method `contains_key`
     |
     = note: multiple `impl`s satisfying `std::string::String: Borrow<_>` found in the following crates: `alloc`, `bstr`, `core`:
             - impl Borrow<bstr::bstr::BStr> for std::string::String;
             - impl Borrow<str> for std::string::String;
             - impl<T> Borrow<T> for T
               where T: ?Sized;
note: required by a bound in `HashMap::<K, V, S>::contains_key`
    --> /home/admin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/collections/hash/map.rs:1145:12
     |
1143 |     pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
     |            ------------ required by a bound in this associated function
1144 |     where
1145 |         K: Borrow<Q>,
     |            ^^^^^^^^^ required by this bound in `HashMap::<K, V, S>::contains_key`
help: consider specifying the generic argument
     |
 186 |             || (!self.packages.contains_key::<Q>(pkg.name.as_ref())
     |                                            +++++

error[E0283]: type annotations needed
   --> src/library.rs:186:32
    |
186 |             || (!self.packages.contains_key(pkg.name.as_ref())
    |                                ^^^^^^^^^^^^          ------ type must be known at this point
    |                                |
    |                                cannot infer type of the type parameter `Q` declared on the method `contains_key`
    |
    = note: multiple `impl`s satisfying `Cow<'_, str>: AsRef<_>` found in the following crates: `alloc`, `typed_path`:
            - impl<T> AsRef<T> for Cow<'_, T>
              where T: ToOwned, T: ?Sized;
            - impl<T> AsRef<typed_path::common::utf8::path::Utf8Path<T>> for Cow<'_, str>
              where T: typed_path::common::utf8::Utf8Encoding;
help: consider specifying the generic argument
    |
186 |             || (!self.packages.contains_key::<Q>(pkg.name.as_ref())
    |                                            +++++
```
    
    after installs cleanly