### PR TITLE
Show if we have cached binary in cache for source package

### DIFF
--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -187,7 +187,11 @@ fn print_grouped_changes(changes: &[SyncChange], dry_run: bool, supports_sysdeps
         .map(|c| c.version.as_ref().map(|v| v.len()).unwrap_or(0))
         .max()
         .unwrap_or(0);
-    let max_kind = 6; // "binary" or "source"
+    let max_kind = installed
+        .iter()
+        .map(|c| c.kind_display().len())
+        .max()
+        .unwrap_or(0);
     let max_source = installed
         .iter()
         .map(|c| c.source_display().len())
@@ -218,7 +222,7 @@ fn print_grouped_changes(changes: &[SyncChange], dry_run: bool, supports_sysdeps
                         "  + {:<name_w$}  {:>ver_w$}  {:<kind_w$}  {:<src_w$}{}{}",
                         c.name,
                         c.version.as_ref().unwrap(),
-                        c.kind.unwrap(),
+                        c.kind_display(),
                         c.source_display(),
                         timing_str,
                         sys_deps_str,


### PR DESCRIPTION
```
From local cache (9):
  + DBI        1.2.3  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + Rcpp      1.0.14  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + classInt  0.4-11  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + e1071     1.7-16  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + magrittr   2.0.3  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + proxy     0.4-27  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + s2         1.1.7  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + units      0.8-7  source    https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
  + wk         0.9.4  compiled  https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26

To Download (1):
  + sf        1.0-20  source    https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-04-26
```