### PR TITLE
feat: add `RV_LIBRARY_DIR` env var override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ logs/
 dist/
 global-cache/
 drift-reviews/
+
+# Claude code
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,12 @@ All environment variable names are defined in `src/consts.rs`.
 | `RV_GLOBAL_CACHE_DIR` | unset | Path to shared cache for multi-user systems. Directory must exist |
 | `PKGCACHE_TIMEOUT` | 3600 (1 hour) | Package database cache TTL in seconds. Compatible with R's pkgcache |
 
+### Library Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RV_LIBRARY_DIR` | unset | Override the project library directory. Supports absolute and relative paths (resolved against project dir). Takes precedence over the `library` field in `rproject.toml` |
+
 ### Performance Tuning
 
 | Variable | Default | Description |

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -27,6 +27,7 @@ pub const CACHE_DIR_ENV_VAR_NAME: &str = "RV_CACHE_DIR";
 pub const COPY_THREADS_ENV_VAR_NAME: &str = "RV_COPY_THREADS";
 pub const GLOBAL_CACHE_DIR_ENV_VAR_NAME: &str = "RV_GLOBAL_CACHE_DIR";
 pub const INSECURE_TLS_ENV_VAR_NAME: &str = "RV_INSECURE";
+pub const LIBRARY_DIR_ENV_VAR_NAME: &str = "RV_LIBRARY_DIR";
 
 // List obtained from the REPL: `rownames(installed.packages(priority="base"))`
 // Those will have the same version as R

--- a/src/context.rs
+++ b/src/context.rs
@@ -137,7 +137,9 @@ impl Context {
             None
         };
 
-        let mut library = if let Some(p) = config.library() {
+        let mut library = if let Ok(p) = std::env::var(crate::consts::LIBRARY_DIR_ENV_VAR_NAME) {
+            Library::new_custom(&project_dir, PathBuf::from(p))
+        } else if let Some(p) = config.library() {
             Library::new_custom(&project_dir, p)
         } else {
             Library::new(&project_dir, cache.system_info(), r_version.major_minor())

--- a/tests/cli_library_dir.rs
+++ b/tests/cli_library_dir.rs
@@ -3,31 +3,24 @@ use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
 
-fn create_test_project() -> (TempDir, std::path::PathBuf) {
-    let temp_dir = TempDir::new().unwrap();
-    let config_path = temp_dir.path().join("rproject.toml");
-
-    let config_content = r#"[project]
-name = "test"
-r_version = "4.5"
-repositories = [
-    {alias = "posit", url = "https://packagemanager.posit.co/cran/2024-12-16/"}
-]
-dependencies = []
-"#;
-
-    fs::write(&config_path, config_content).unwrap();
-    (temp_dir, config_path)
+/// Normalize path separators to forward slashes for cross-platform comparison.
+/// rv outputs forward slashes on Windows, but TempDir/PathBuf uses backslashes.
+fn normalize_path(p: &str) -> String {
+    p.replace('\\', "/")
 }
 
-fn create_test_project_with_library(lib: &str) -> (TempDir, std::path::PathBuf) {
+fn create_test_project(library_field: Option<&str>) -> (TempDir, std::path::PathBuf) {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("rproject.toml");
 
-    let config_content = format!(
-        r#"library = "{lib}"
+    let library_line = match library_field {
+        Some(lib) => format!("library = \"{lib}\"\n\n"),
+        None => String::new(),
+    };
 
-[project]
+    // Need to escape braces for the toml array when using format!
+    let config_content = format!(
+        r#"{library_line}[project]
 name = "test"
 r_version = "4.5"
 repositories = [
@@ -48,21 +41,29 @@ fn rv_cmd(cache: &Path, config: &Path) -> assert_cmd::Command {
     cmd
 }
 
-#[test]
-fn test_default_library_path() {
-    let cache = TempDir::new().unwrap();
-    let (temp_dir, config_path) = create_test_project();
-
-    let mut cmd = rv_cmd(cache.path(), &config_path);
+fn get_library_path(cache: &Path, config: &Path, env_var: Option<&str>) -> String {
+    let mut cmd = rv_cmd(cache, config);
+    if let Some(val) = env_var {
+        cmd.env("RV_LIBRARY_DIR", val);
+    } else {
+        cmd.env_remove("RV_LIBRARY_DIR");
+    }
     cmd.arg("library");
 
     let output = cmd.output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let library_path = stdout.trim();
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
 
-    // Default library path should be under rv/library/ in the project dir
+#[test]
+fn test_default_library_path() {
+    let cache = TempDir::new().unwrap();
+    let (temp_dir, config_path) = create_test_project(None);
+
+    let library_path = get_library_path(cache.path(), &config_path, None);
+    let project_dir = normalize_path(&temp_dir.path().to_string_lossy());
+
     assert!(
-        library_path.starts_with(&temp_dir.path().to_string_lossy().to_string()),
+        library_path.starts_with(&project_dir),
         "library path should be under project dir, got: {library_path}"
     );
     assert!(
@@ -71,88 +72,100 @@ fn test_default_library_path() {
     );
 }
 
+/// Tests for RV_LIBRARY_DIR env var and config file `library` field interactions.
+///
+/// Each case: (description, config library field, env var, expected path suffix or absolute)
 #[test]
-fn test_env_var_absolute_path() {
+fn test_library_dir_resolution() {
+    struct Case {
+        name: &'static str,
+        config_library: Option<&'static str>,
+        env_var: Option<&'static str>,
+        /// If true, the expected path is the env var value used as an absolute path (via a temp dir).
+        /// If false, expected is project_dir.join(expected_suffix).
+        expect_absolute_env: bool,
+        expected_suffix: &'static str,
+    }
+
+    let cases = [
+        Case {
+            name: "env var relative path resolves against project dir",
+            config_library: None,
+            env_var: Some("my-libs"),
+            expect_absolute_env: false,
+            expected_suffix: "my-libs",
+        },
+        Case {
+            name: "env var overrides config library field",
+            config_library: Some("libs"),
+            env_var: Some("__ABSOLUTE__"),
+            expect_absolute_env: true,
+            expected_suffix: "",
+        },
+        Case {
+            name: "config library field used when env var not set",
+            config_library: Some("libs"),
+            env_var: None,
+            expect_absolute_env: false,
+            expected_suffix: "libs",
+        },
+        Case {
+            name: "env var absolute path used directly",
+            config_library: None,
+            env_var: Some("__ABSOLUTE__"),
+            expect_absolute_env: true,
+            expected_suffix: "",
+        },
+    ];
+
+    for case in &cases {
+        let cache = TempDir::new().unwrap();
+        let (temp_dir, config_path) = create_test_project(case.config_library);
+
+        // For absolute path tests, create a real temp dir to use as the env var value
+        let abs_dir = TempDir::new().unwrap();
+        let env_val = match case.env_var {
+            Some("__ABSOLUTE__") => Some(abs_dir.path().to_str().unwrap().to_string()),
+            Some(v) => Some(v.to_string()),
+            None => None,
+        };
+
+        let library_path = get_library_path(cache.path(), &config_path, env_val.as_deref());
+
+        let expected = if case.expect_absolute_env {
+            normalize_path(&abs_dir.path().to_string_lossy())
+        } else {
+            normalize_path(&temp_dir.path().join(case.expected_suffix).to_string_lossy())
+        };
+
+        assert_eq!(library_path, expected, "FAILED: {}", case.name);
+    }
+}
+
+/// The activate.R script calls `rv info --library` at R startup to determine
+/// the library path. Verify that this command respects RV_LIBRARY_DIR.
+#[test]
+fn test_info_library_respects_env_var() {
     let cache = TempDir::new().unwrap();
-    let (_temp_dir, config_path) = create_test_project();
+    let (_temp_dir, config_path) = create_test_project(None);
     let custom_lib = TempDir::new().unwrap();
 
     let mut cmd = rv_cmd(cache.path(), &config_path);
     cmd.env("RV_LIBRARY_DIR", custom_lib.path());
-    cmd.arg("library");
+    cmd.args(["info", "--library"]);
 
     let output = cmd.output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let library_path = stdout.trim();
+
+    // rv info --library outputs "library: <path>"
+    let library_path = stdout
+        .trim()
+        .strip_prefix("library: ")
+        .expect("expected 'library: ' prefix in rv info output");
 
     assert_eq!(
         library_path,
-        custom_lib.path().to_string_lossy().to_string(),
-        "RV_LIBRARY_DIR absolute path should be used directly"
-    );
-}
-
-#[test]
-fn test_env_var_relative_path() {
-    let cache = TempDir::new().unwrap();
-    let (temp_dir, config_path) = create_test_project();
-
-    let mut cmd = rv_cmd(cache.path(), &config_path);
-    cmd.env("RV_LIBRARY_DIR", "my-libs");
-    cmd.arg("library");
-
-    let output = cmd.output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let library_path = stdout.trim();
-
-    let expected = temp_dir.path().join("my-libs");
-    assert_eq!(
-        library_path,
-        expected.to_string_lossy().to_string(),
-        "RV_LIBRARY_DIR relative path should resolve against project dir"
-    );
-}
-
-#[test]
-fn test_env_var_overrides_config() {
-    let cache = TempDir::new().unwrap();
-    let (_temp_dir, config_path) = create_test_project_with_library("libs");
-    let custom_lib = TempDir::new().unwrap();
-
-    let mut cmd = rv_cmd(cache.path(), &config_path);
-    cmd.env("RV_LIBRARY_DIR", custom_lib.path());
-    cmd.arg("library");
-
-    let output = cmd.output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let library_path = stdout.trim();
-
-    // Env var should win over config file
-    assert_eq!(
-        library_path,
-        custom_lib.path().to_string_lossy().to_string(),
-        "RV_LIBRARY_DIR should override library config in rproject.toml"
-    );
-}
-
-#[test]
-fn test_config_library_without_env_var() {
-    let cache = TempDir::new().unwrap();
-    let (temp_dir, config_path) = create_test_project_with_library("libs");
-
-    let mut cmd = rv_cmd(cache.path(), &config_path);
-    // Explicitly remove RV_LIBRARY_DIR to ensure it's not set
-    cmd.env_remove("RV_LIBRARY_DIR");
-    cmd.arg("library");
-
-    let output = cmd.output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let library_path = stdout.trim();
-
-    let expected = temp_dir.path().join("libs");
-    assert_eq!(
-        library_path,
-        expected.to_string_lossy().to_string(),
-        "config library should be used when RV_LIBRARY_DIR is not set"
+        normalize_path(&custom_lib.path().to_string_lossy()),
+        "rv info --library should respect RV_LIBRARY_DIR during activation"
     );
 }

--- a/tests/cli_library_dir.rs
+++ b/tests/cli_library_dir.rs
@@ -1,0 +1,158 @@
+use assert_cmd::cargo;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn create_test_project() -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("rproject.toml");
+
+    let config_content = r#"[project]
+name = "test"
+r_version = "4.5"
+repositories = [
+    {alias = "posit", url = "https://packagemanager.posit.co/cran/2024-12-16/"}
+]
+dependencies = []
+"#;
+
+    fs::write(&config_path, config_content).unwrap();
+    (temp_dir, config_path)
+}
+
+fn create_test_project_with_library(lib: &str) -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("rproject.toml");
+
+    let config_content = format!(
+        r#"library = "{lib}"
+
+[project]
+name = "test"
+r_version = "4.5"
+repositories = [
+    {{alias = "posit", url = "https://packagemanager.posit.co/cran/2024-12-16/"}}
+]
+dependencies = []
+"#
+    );
+
+    fs::write(&config_path, config_content).unwrap();
+    (temp_dir, config_path)
+}
+
+fn rv_cmd(cache: &Path, config: &Path) -> assert_cmd::Command {
+    let mut cmd = cargo::cargo_bin_cmd!();
+    cmd.env("RV_CACHE_DIR", cache);
+    cmd.args(["--config-file", config.to_str().unwrap()]);
+    cmd
+}
+
+#[test]
+fn test_default_library_path() {
+    let cache = TempDir::new().unwrap();
+    let (temp_dir, config_path) = create_test_project();
+
+    let mut cmd = rv_cmd(cache.path(), &config_path);
+    cmd.arg("library");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let library_path = stdout.trim();
+
+    // Default library path should be under rv/library/ in the project dir
+    assert!(
+        library_path.starts_with(&temp_dir.path().to_string_lossy().to_string()),
+        "library path should be under project dir, got: {library_path}"
+    );
+    assert!(
+        library_path.contains("rv/library"),
+        "default library path should contain rv/library, got: {library_path}"
+    );
+}
+
+#[test]
+fn test_env_var_absolute_path() {
+    let cache = TempDir::new().unwrap();
+    let (_temp_dir, config_path) = create_test_project();
+    let custom_lib = TempDir::new().unwrap();
+
+    let mut cmd = rv_cmd(cache.path(), &config_path);
+    cmd.env("RV_LIBRARY_DIR", custom_lib.path());
+    cmd.arg("library");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let library_path = stdout.trim();
+
+    assert_eq!(
+        library_path,
+        custom_lib.path().to_string_lossy().to_string(),
+        "RV_LIBRARY_DIR absolute path should be used directly"
+    );
+}
+
+#[test]
+fn test_env_var_relative_path() {
+    let cache = TempDir::new().unwrap();
+    let (temp_dir, config_path) = create_test_project();
+
+    let mut cmd = rv_cmd(cache.path(), &config_path);
+    cmd.env("RV_LIBRARY_DIR", "my-libs");
+    cmd.arg("library");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let library_path = stdout.trim();
+
+    let expected = temp_dir.path().join("my-libs");
+    assert_eq!(
+        library_path,
+        expected.to_string_lossy().to_string(),
+        "RV_LIBRARY_DIR relative path should resolve against project dir"
+    );
+}
+
+#[test]
+fn test_env_var_overrides_config() {
+    let cache = TempDir::new().unwrap();
+    let (_temp_dir, config_path) = create_test_project_with_library("libs");
+    let custom_lib = TempDir::new().unwrap();
+
+    let mut cmd = rv_cmd(cache.path(), &config_path);
+    cmd.env("RV_LIBRARY_DIR", custom_lib.path());
+    cmd.arg("library");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let library_path = stdout.trim();
+
+    // Env var should win over config file
+    assert_eq!(
+        library_path,
+        custom_lib.path().to_string_lossy().to_string(),
+        "RV_LIBRARY_DIR should override library config in rproject.toml"
+    );
+}
+
+#[test]
+fn test_config_library_without_env_var() {
+    let cache = TempDir::new().unwrap();
+    let (temp_dir, config_path) = create_test_project_with_library("libs");
+
+    let mut cmd = rv_cmd(cache.path(), &config_path);
+    // Explicitly remove RV_LIBRARY_DIR to ensure it's not set
+    cmd.env_remove("RV_LIBRARY_DIR");
+    cmd.arg("library");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let library_path = stdout.trim();
+
+    let expected = temp_dir.path().join("libs");
+    assert_eq!(
+        library_path,
+        expected.to_string_lossy().to_string(),
+        "config library should be used when RV_LIBRARY_DIR is not set"
+    );
+}


### PR DESCRIPTION
`rv info` returns the correct path when set via env var:
```
~/Projects/a2-ai/rv/example_projects/simple feat/library-dir-env-var *2 !1 ?1                           1.93.1
❯ RV_LIBRARY_DIR=/private/tmp/rv-temp-dir rv info --library
library: /private/tmp/rv-temp-dir
```
and in R:
```
~/Projects/a2-ai/rv/example_projects/simple feat/library-dir-env-var *2 !1 ?1                           1.93.1
❯ RV_LIBRARY_DIR=/private/tmp/rv-temp-dir R

R version 4.5.3 (2026-03-11) -- "Reassured Reassurer"
Copyright (C) 2026 The R Foundation for Statistical Computing
Platform: aarch64-apple-darwin25.3.0

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

rv repositories active!
repositories:
  posit: https://packagemanager.posit.co/cran/2025-05-12

rv libpaths active!
library paths:
  /private/tmp/rv-temp-dir
  /opt/homebrew/Cellar/r/4.5.3/lib/R/library
>
```