### PR TITLE
filename of parent of renv_file instead of absolute path

### DIFF
--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -35,7 +35,8 @@ pub fn migrate_renv(
     let abs_renv_file = absolute(renv_file.as_ref())?;
     let project_name = abs_renv_file
         .parent()
-        .and_then(|p| p.to_str())
+        .and_then(|p| p.file_name())
+        .and_then(|f| f.to_str())
         .unwrap_or("renv migrated project");
 
     // use the repositories and r version from the renv.lock to determine the repository databases


### PR DESCRIPTION
Found when running `rv migrate renv` the absolute path to the directory was the project title. This PR fixes that by taking the  filename of the parent of the renv.lock. i.e. `/path/to/project/renv.lock` --parent--> `/path/to/project` --filename--> `project`