### PR TITLE
Git cache status

### DIFF
--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -254,7 +254,16 @@ impl DiskCache {
             false
         };
 
-        match (source_path.is_dir(), binary_path.is_dir()) {
+        // Git sources may be in a sparse-only state from resolution (only DESCRIPTION
+        // files materialized). Treat those as not having source available.
+        let source_present = match source {
+            Source::Git { .. } | Source::RUniverse { .. } => {
+                source_path.is_dir() && has_full_git_source(&source_path)
+            }
+            _ => source_path.is_dir(),
+        };
+
+        match (source_present, binary_path.is_dir()) {
             (true, true) => InstallationStatus::Both(from_source),
             (true, false) => InstallationStatus::Source,
             (false, true) => InstallationStatus::Binary(from_source),
@@ -295,5 +304,34 @@ impl DiskCache {
             fs::write(&path, content).expect("to work");
             sysreq
         }
+    }
+}
+
+/// During resolution we sparse-checkout only `**/DESCRIPTION`, so the cache dir
+/// holds just `.git/` plus a DESCRIPTION file but it shouldn't count as having the source
+fn has_full_git_source(path: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(path) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let name = entry.file_name();
+        name != ".git" && name != "DESCRIPTION"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_full_git_source_distinguishes_sparse_from_full() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".git").join("HEAD"), "ref").unwrap();
+        fs::write(dir.path().join("DESCRIPTION"), "Package: x\n").unwrap();
+        assert!(!has_full_git_source(dir.path()));
+
+        fs::write(dir.path().join("NAMESPACE"), "").unwrap();
+        assert!(has_full_git_source(dir.path()));
     }
 }

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 use filetime::FileTime;
 use fs_err as fs;
 use url::Url;
+use walkdir::WalkDir;
 
 use crate::cache::InstallationStatus;
 use crate::cache::utils::{
@@ -307,31 +308,64 @@ impl DiskCache {
     }
 }
 
-/// During resolution we sparse-checkout only `**/DESCRIPTION`, so the cache dir
-/// holds just `.git/` plus a DESCRIPTION file but it shouldn't count as having the source
+/// During resolution we sparse-checkout `**/DESCRIPTION`, so the cache dir holds
+/// just `.git/` plus DESCRIPTION files (possibly nested in a package subdir,
+/// which leaves an otherwise-empty parent directory at the top level). It
+/// shouldn't count as having the source. Walk recursively, skip the `.git`
+/// subtree, and only count regular files other than DESCRIPTION.
 fn has_full_git_source(path: &Path) -> bool {
-    let Ok(entries) = fs::read_dir(path) else {
-        return false;
-    };
-    entries.flatten().any(|entry| {
-        let name = entry.file_name();
-        name != ".git" && name != "DESCRIPTION"
-    })
+    WalkDir::new(path)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|e| e.file_name() != ".git")
+        .filter_map(Result::ok)
+        .any(|e| e.file_type().is_file() && e.file_name() != "DESCRIPTION")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn make_sparse_repo(root: &Path) {
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".git").join("HEAD"), "ref").unwrap();
+        fs::write(root.join(".git").join("config"), "[core]\n").unwrap();
+    }
+
     #[test]
     fn has_full_git_source_distinguishes_sparse_from_full() {
         let dir = tempfile::tempdir().unwrap();
-        fs::create_dir(dir.path().join(".git")).unwrap();
-        fs::write(dir.path().join(".git").join("HEAD"), "ref").unwrap();
+        make_sparse_repo(dir.path());
         fs::write(dir.path().join("DESCRIPTION"), "Package: x\n").unwrap();
         assert!(!has_full_git_source(dir.path()));
 
         fs::write(dir.path().join("NAMESPACE"), "").unwrap();
         assert!(has_full_git_source(dir.path()));
+    }
+
+    #[test]
+    fn has_full_git_source_handles_nested_description() {
+        let dir = tempfile::tempdir().unwrap();
+        make_sparse_repo(dir.path());
+        fs::create_dir(dir.path().join("pkg")).unwrap();
+        fs::write(dir.path().join("pkg").join("DESCRIPTION"), "Package: x\n").unwrap();
+        assert!(!has_full_git_source(dir.path()));
+
+        fs::write(dir.path().join("pkg").join("NAMESPACE"), "").unwrap();
+        assert!(has_full_git_source(dir.path()));
+    }
+
+    #[test]
+    fn has_full_git_source_ignores_files_inside_dot_git() {
+        let dir = tempfile::tempdir().unwrap();
+        make_sparse_repo(dir.path());
+        fs::create_dir(dir.path().join(".git").join("objects")).unwrap();
+        fs::write(
+            dir.path().join(".git").join("objects").join("pack"),
+            "stuff",
+        )
+        .unwrap();
+        fs::write(dir.path().join("DESCRIPTION"), "Package: x\n").unwrap();
+        assert!(!has_full_git_source(dir.path()));
     }
 }

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -170,7 +170,9 @@ impl GitRepository {
                     .arg(oid.as_str())
                     .current_dir(&self.path),
             )
-            .map_err(|_| std::io::Error::other(format!("Failed to checkout `{}`", oid.as_str())))?;
+            .map_err(|e| {
+                std::io::Error::other(format!("Failed to checkout `{}`: {e}", oid.as_str()))
+            })?;
 
         self.update_submodules()?;
         Ok(())
@@ -190,8 +192,8 @@ impl GitRepository {
                     .arg(format!("origin/{branch_name}"))
                     .current_dir(&self.path),
             )
-            .map_err(|_| {
-                std::io::Error::other(format!("Failed to checkout branch `{branch_name}`"))
+            .map_err(|e| {
+                std::io::Error::other(format!("Failed to checkout branch `{branch_name}`: {e}"))
             })?;
 
         self.update_submodules()?;
@@ -347,7 +349,7 @@ impl GitRepository {
                     .arg("--recursive")
                     .current_dir(&self.path),
             )
-            .map_err(|_| std::io::Error::other("Failed to update submodules".to_string()))?;
+            .map_err(|e| std::io::Error::other(format!("Failed to update submodules: {e}")))?;
         Ok(())
     }
 
@@ -411,31 +413,24 @@ fn fetch_with_cli(
     executor: &dyn CommandExecutor,
 ) -> Result<(), std::io::Error> {
     // https://github.com/astral-sh/uv/blob/main/crates/uv-git/src/git.rs#L572-L617
-    let _ = executor
-        .execute(
-            Command::new("git")
-                .arg("fetch")
-                .arg("--tags")
-                .arg("--force")
-                .arg("--update-head-ok")
-                .arg(url)
-                .arg(refspec)
-                .current_dir(&repo.path)
-                // Disable interactive prompts
-                .env("GIT_TERMINAL_PROMPT", "0")
-                // From Cargo
-                // If rv is run by git (for example, the `exec` command in `git
-                // rebase`), the GIT_DIR is set by git and will point to the wrong
-                // location (this takes precedence over the cwd). Make sure this is
-                // unset so git will look at cwd for the repo.
-                .env_remove("GIT_DIR"),
-        )
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not fetch repository".to_string(),
-            )
-        })?;
+    executor.execute(
+        Command::new("git")
+            .arg("fetch")
+            .arg("--tags")
+            .arg("--force")
+            .arg("--update-head-ok")
+            .arg(url)
+            .arg(refspec)
+            .current_dir(&repo.path)
+            // Disable interactive prompts
+            .env("GIT_TERMINAL_PROMPT", "0")
+            // From Cargo
+            // If rv is run by git (for example, the `exec` command in `git
+            // rebase`), the GIT_DIR is set by git and will point to the wrong
+            // location (this takes precedence over the cwd). Make sure this is
+            // unset so git will look at cwd for the repo.
+            .env_remove("GIT_DIR"),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
Before:
```
From local cache (1):
  + hyperion    0.4.2  source  git@github.com:A2-ai/hyperion.git              

To Download (11):
  + S7          0.2.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + cli         3.6.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + evaluate    1.0.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + fs          2.0.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + highr        0.12  source  https://packagemanager.posit.co/cran/2026-04-01
  + knitr        1.51  source  https://packagemanager.posit.co/cran/2026-04-01
  + lifecycle   1.0.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + rlang       1.1.7  source  https://packagemanager.posit.co/cran/2026-04-01
  + tomledit    0.1.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + xfun         0.57  source  https://packagemanager.posit.co/cran/2026-04-01
  + yaml       2.3.12  source  https://packagemanager.posit.co/cran/2026-04-01
```

After: 
```
To Download (12):
  + S7          0.2.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + cli         3.6.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + evaluate    1.0.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + fs          2.0.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + highr        0.12  source  https://packagemanager.posit.co/cran/2026-04-01
  + hyperion    0.4.2  source  git@github.com:A2-ai/hyperion.git              
  + knitr        1.51  source  https://packagemanager.posit.co/cran/2026-04-01
  + lifecycle   1.0.5  source  https://packagemanager.posit.co/cran/2026-04-01
  + rlang       1.1.7  source  https://packagemanager.posit.co/cran/2026-04-01
  + tomledit    0.1.1  source  https://packagemanager.posit.co/cran/2026-04-01
  + xfun         0.57  source  https://packagemanager.posit.co/cran/2026-04-01
  + yaml       2.3.12  source  https://packagemanager.posit.co/cran/2026-04-01
```