### PR TITLE
feat: add global --r-bin cli argument

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,18 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cargo": {
+          "features": "all",
+        },
+        "check": {
+          "command": "clippy",
+        },
+      },
+    },
+  },
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,6 +30,8 @@ pub enum RCommandLookup {
     /// Used when finding the RCommand is not required, primarily for information commands like
     /// cache, library, etc.
     Skip,
+    /// Use a specific R binary directly, bypassing all discovery
+    Explicit(RInstall),
 }
 
 impl From<Option<Version>> for RCommandLookup {
@@ -93,22 +95,27 @@ impl Context {
         let r_version = match r_command_lookup {
             RCommandLookup::Strict | RCommandLookup::Skip => config.r_version().clone(),
             RCommandLookup::Soft(ref v) => v.clone(),
+            RCommandLookup::Explicit(ref install) => install.version.clone(),
         };
-        let r_cmd = match find_r_install(&r_version, config.use_devel()) {
-            Some(r_install) => r_install,
-            None => match r_command_lookup {
-                RCommandLookup::Strict => {
-                    return Err(format!(
-                        "Could not find an R version matching {}",
-                        r_version.original
-                    )
-                    .into());
-                }
-                RCommandLookup::Soft(_) => {
-                    r_version_found = false;
-                    RInstall::default_from_path()
-                }
-                RCommandLookup::Skip => RInstall::default_from_path(),
+        let r_cmd = match r_command_lookup {
+            RCommandLookup::Explicit(install) => install,
+            _ => match find_r_install(&r_version, config.use_devel()) {
+                Some(r_install) => r_install,
+                None => match r_command_lookup {
+                    RCommandLookup::Strict => {
+                        return Err(format!(
+                            "Could not find an R version matching {}",
+                            r_version.original
+                        )
+                        .into());
+                    }
+                    RCommandLookup::Soft(_) => {
+                        r_version_found = false;
+                        RInstall::default_from_path()
+                    }
+                    RCommandLookup::Skip => RInstall::default_from_path(),
+                    RCommandLookup::Explicit(_) => unreachable!(),
+                },
             },
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use rv::cli::{
     Context, OutputFormat, RCommandLookup, ResolveMode, SyncHelper, export_renv,
     find_r_repositories, init, init_structure, migrate_renv, resolve_dependencies, tree,
 };
-use rv::r_finder::get_r_from_path;
+use rv::r_finder::{RInstall, get_r_from_path};
 use rv::system_req::{SysDep, SysInstallationStatus};
 use rv::{AddOptions, RepositoryOperation as LibRepositoryOperation};
 use rv::{
@@ -36,6 +36,10 @@ pub struct Cli {
     /// Path to a config file other than rproject.toml in the current directory
     #[clap(short = 'c', long, default_value = "rproject.toml", global = true)]
     pub config_file: PathBuf,
+
+    /// Path to an R binary to use instead of automatic discovery
+    #[clap(long, global = true)]
+    pub r_bin: Option<PathBuf>,
 
     #[clap(subcommand)]
     pub command: Command,
@@ -344,6 +348,11 @@ fn try_main() -> Result<()> {
         .filter(Some("os_info"), log::LevelFilter::Off)
         .init();
 
+    let r_lookup = match cli.r_bin {
+        Some(ref bin) => RCommandLookup::Explicit(RInstall::try_from_bin(bin)?),
+        None => RCommandLookup::Strict,
+    };
+
     match cli.command {
         Command::Init {
             project_directory,
@@ -490,8 +499,8 @@ fn try_main() -> Result<()> {
         Command::Sync {
             save_install_logs_in,
         } => {
-            let mut context = Context::new(&cli.config_file, RCommandLookup::Strict)
-                .map_err(|e| anyhow!("{e}"))?;
+            let mut context =
+                Context::new(&cli.config_file, r_lookup.clone()).map_err(|e| anyhow!("{e}"))?;
 
             if !log_enabled {
                 context.show_progress_bar();
@@ -575,8 +584,8 @@ fn try_main() -> Result<()> {
                 }
                 return Ok(());
             }
-            let mut context = Context::new(&cli.config_file, RCommandLookup::Strict)
-                .map_err(|e| anyhow!("{e}"))?;
+            let mut context =
+                Context::new(&cli.config_file, r_lookup.clone()).map_err(|e| anyhow!("{e}"))?;
 
             if !log_enabled {
                 context.show_progress_bar();
@@ -623,8 +632,8 @@ fn try_main() -> Result<()> {
                 return Ok(());
             }
 
-            let mut context = Context::new(&cli.config_file, RCommandLookup::Strict)
-                .map_err(|e| anyhow!("{e}"))?;
+            let mut context =
+                Context::new(&cli.config_file, r_lookup.clone()).map_err(|e| anyhow!("{e}"))?;
 
             if !log_enabled {
                 context.show_progress_bar();
@@ -647,8 +656,8 @@ fn try_main() -> Result<()> {
             .run(&context, resolve_mode)?;
         }
         Command::Upgrade { dry_run } => {
-            let mut context = Context::new(&cli.config_file, RCommandLookup::Strict)
-                .map_err(|e| anyhow!("{e}"))?;
+            let mut context =
+                Context::new(&cli.config_file, r_lookup.clone()).map_err(|e| anyhow!("{e}"))?;
 
             if !log_enabled {
                 context.show_progress_bar();
@@ -953,8 +962,8 @@ fn try_main() -> Result<()> {
         }
 
         Command::Run { args } => {
-            let context = Context::new(&cli.config_file, RCommandLookup::Strict)
-                .map_err(|e| anyhow!("{e}"))?;
+            let context =
+                Context::new(&cli.config_file, r_lookup.clone()).map_err(|e| anyhow!("{e}"))?;
             let code = rv::run(&context.r_cmd.bin_path, context.library_path(), &args)?;
             std::process::exit(code);
         }

--- a/src/r_finder.rs
+++ b/src/r_finder.rs
@@ -53,6 +53,29 @@ impl RInstall {
             is_devel: false,
         }
     }
+
+    #[cfg(feature = "cli")]
+    pub fn try_from_bin<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let bin_path = path.as_ref().to_path_buf();
+
+        anyhow::ensure!(bin_path.exists(), "R binary not found: {:?}", bin_path);
+
+        // R binary one level up is resources then we go to inlcude/Rversion.h to read from
+        let parent = bin_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine parent from path: {:?}", bin_path))?;
+
+        let header = parent.join("include").join("Rversion.h");
+
+        let (version, is_devel) = read_version_from_header(&header)
+            .ok_or_else(|| anyhow::anyhow!("Could not read version from {:?}", header))?;
+
+        Ok(Self {
+            bin_path,
+            version,
+            is_devel,
+        })
+    }
 }
 
 impl Display for RInstall {


### PR DESCRIPTION
This PR closes #447.

It works by adding a new `--r-bin` argument that  adding a new `RCommandLookup::Explicit` variant which, when provided, will (fallibly) create an `RInstall` from the binary path.

Default behavior: 
<img width="718" height="641" alt="image" src="https://github.com/user-attachments/assets/0016b93f-2180-4b42-9dd5-f1f00c9a0187" />

When specifying bin path: 

<img width="767" height="593" alt="image" src="https://github.com/user-attachments/assets/b6838ca4-bde6-40ba-bd8f-25135120c220" />

Note that it properly creates the 4.6 subdirectory in addition to the default 4.5 version

```bash
waiting ⚡ ll rv/library
total 0
drwxr-xr-x@ 4 josiahparry  staff   128B May  5 10:40 .
drwxr-xr-x@ 5 josiahparry  staff   160B May  5 10:33 ..
drwxr-xr-x@ 3 josiahparry  staff    96B May  5 10:35 4.5
drwxr-xr-x@ 3 josiahparry  staff    96B May  5 10:40 4.6
```