### PR TITLE
Better message for add/remove when syncing fails

### DIFF
--- a/src/dependency_edit.rs
+++ b/src/dependency_edit.rs
@@ -75,11 +75,13 @@ pub fn read_and_verify_config(
     Ok(config_content.parse::<DocumentMut>().unwrap()) // Verify config was valid toml above
 }
 
+/// Adds the given packages to the dependencies array, skipping any already present.
+/// Returns the names of packages actually appended (in input order).
 pub fn add_packages(
     config_doc: &mut DocumentMut,
     packages: Vec<String>,
     options: AddOptions,
-) -> Result<(), DependencyEditError> {
+) -> Result<Vec<String>, DependencyEditError> {
     // get the dependencies array
     let config_deps = get_mut_array(config_doc);
 
@@ -94,6 +96,7 @@ pub fn add_packages(
         .map(|s| s.to_string()) // Need to allocate so values are not a reference to a mut
         .collect::<Vec<_>>();
 
+    let mut added = Vec::new();
     // Determine if the dep to add is in the config, if not add it
     for package_name in packages {
         if !config_dep_names.contains(&package_name) {
@@ -103,6 +106,7 @@ pub fn add_packages(
             if let Some(last) = config_deps.iter_mut().last() {
                 last.decor_mut().set_prefix("\n    ");
             }
+            added.push(package_name);
         }
     }
 
@@ -110,7 +114,7 @@ pub fn add_packages(
     config_deps.set_trailing("\n");
     config_deps.set_trailing_comma(true);
 
-    Ok(())
+    Ok(added)
 }
 
 fn create_dependency_value(
@@ -193,13 +197,15 @@ fn get_mut_array(doc: &mut DocumentMut) -> &mut Array {
     deps
 }
 
+/// Removes the given packages from the dependencies array.
+/// Returns the names of packages actually removed (in the order they appeared in the config).
 pub fn remove_packages(
     config_doc: &mut DocumentMut,
     packages: Vec<String>,
-) -> Result<(), DependencyEditError> {
+) -> Result<Vec<String>, DependencyEditError> {
     let config_deps = get_mut_array(config_doc);
 
-    // Remove packages that match the names provided
+    let mut removed = Vec::new();
     config_deps.retain(|v| {
         let dep_name = match v {
             Value::String(s) => s.value().as_str(),
@@ -207,15 +213,19 @@ pub fn remove_packages(
             _ => "",
         };
 
-        // Keep the element if it doesn't match any package to remove
-        !packages.iter().any(|p| p.as_str() == dep_name)
+        if packages.iter().any(|p| p.as_str() == dep_name) {
+            removed.push(dep_name.to_string());
+            false
+        } else {
+            true
+        }
     });
 
     // Set a trailing new line and comma for the last element for proper formatting
     config_deps.set_trailing("\n");
     config_deps.set_trailing_comma(true);
 
-    Ok(())
+    Ok(removed)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,46 @@ pub enum ExportSubcommand {
     },
 }
 
+fn print_add_summary(output_format: &OutputFormat, added: &[String], dry_run: bool) {
+    if output_format.is_json() {
+        return;
+    }
+    if added.is_empty() {
+        println!("All packages already in rproject.toml. Nothing to add.");
+        return;
+    }
+    let verb = if dry_run { "Would add" } else { "Added" };
+    let noun = if added.len() == 1 {
+        "package"
+    } else {
+        "packages"
+    };
+    println!("{} {} {} to rproject.toml:", verb, added.len(), noun);
+    for name in added {
+        println!("  + {name}");
+    }
+}
+
+fn print_remove_summary(output_format: &OutputFormat, removed: &[String], dry_run: bool) {
+    if output_format.is_json() {
+        return;
+    }
+    if removed.is_empty() {
+        println!("No matching packages in rproject.toml. Nothing to remove.");
+        return;
+    }
+    let verb = if dry_run { "Would remove" } else { "Removed" };
+    let noun = if removed.len() == 1 {
+        "package"
+    } else {
+        "packages"
+    };
+    println!("{} {} {} from rproject.toml:", verb, removed.len(), noun);
+    for name in removed {
+        println!("  - {name}");
+    }
+}
+
 fn try_main() -> Result<()> {
     let cli = Cli::parse();
     let output_format = if cli.json {
@@ -560,18 +600,17 @@ fn try_main() -> Result<()> {
                 }
             }
 
-            add_packages(&mut doc, packages, add_options)?;
+            let added = add_packages(&mut doc, packages, add_options)?;
             // write the update if not dry run
             if !dry_run {
                 write(&cli.config_file, doc.to_string())?;
             }
+            print_add_summary(&output_format, &added, dry_run);
             // if no sync, exit early
             if no_sync {
                 if output_format.is_json() {
                     // Nothing to output for JSON format here since we didn't sync anything
                     println!("{{}}");
-                } else {
-                    println!("Packages successfully added");
                 }
                 return Ok(());
             }
@@ -589,6 +628,9 @@ fn try_main() -> Result<()> {
             context
                 .load_for_resolve_mode(resolve_mode)
                 .map_err(|e| anyhow!("{e}"))?;
+            if !output_format.is_json() {
+                println!("\nResolving dependencies...");
+            }
             SyncHelper {
                 dry_run,
                 output_format: Some(output_format),
@@ -606,19 +648,18 @@ fn try_main() -> Result<()> {
             // Load config to verify structure is valid
             let mut doc = read_and_verify_config(&cli.config_file)?;
 
-            remove_packages(&mut doc, packages)?;
+            let removed = remove_packages(&mut doc, packages)?;
 
             // write the update if not dry run
             if !dry_run {
                 write(&cli.config_file, doc.to_string())?;
             }
+            print_remove_summary(&output_format, &removed, dry_run);
 
             // if no sync, exit early
             if no_sync {
                 if output_format.is_json() {
                     println!("{{}}");
-                } else {
-                    println!("Packages successfully removed");
                 }
                 return Ok(());
             }
@@ -639,6 +680,9 @@ fn try_main() -> Result<()> {
             context
                 .load_for_resolve_mode(resolve_mode)
                 .map_err(|e| anyhow!("{e}"))?;
+            if !output_format.is_json() {
+                println!("\nResolving dependencies...");
+            }
             SyncHelper {
                 dry_run,
                 output_format: Some(output_format),


### PR DESCRIPTION
Closes #438

After: 
```
~/C/a/r/e/test (rv-add-clearer|●2) $ rv add invalid-package
Added 1 package to rproject.toml:
  + invalid-package

Resolving dependencies...
Failed to resolve all dependencies
    invalid-package [listed in rproject.toml]
```