### PR TITLE
transitive suggests test examples

### DIFF
--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -500,6 +500,15 @@ impl<'d> Resolver<'d> {
             .map(|d| d.name())
             .collect();
 
+        // The `install_suggestions` flag needs to apply to the package coming from any sources.
+        // If we don't do that, we might miss some suggested packages because a version constraint
+        // made it come from somewhere else
+        let config_suggests: HashSet<&str> = dependencies
+            .iter()
+            .filter(|d| d.install_suggestions())
+            .map(|d| d.name())
+            .collect();
+
         let mut queue: VecDeque<_> = dependencies
             .iter()
             .map(|d| QueueItem {
@@ -518,7 +527,7 @@ impl<'d> Resolver<'d> {
             })
             .collect();
 
-        while let Some(item) = queue.pop_front() {
+        while let Some(mut item) = queue.pop_front() {
             if let Some(ver_reqs) = processed.get(item.name.as_ref()) {
                 // If we have already found that dependency and it has a forced repo, skip it
                 if repo_required.contains(item.name.as_ref()) {
@@ -529,6 +538,10 @@ impl<'d> Resolver<'d> {
                 if ver_reqs.contains(&item.version_requirement) {
                     continue;
                 }
+            }
+
+            if config_suggests.contains(item.name.as_ref()) {
+                item.install_suggestions = true;
             }
 
             // If we have a local path, we don't need to check anything at all, just the actual path

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -748,7 +748,10 @@ impl<'d> Resolver<'d> {
             }
         }
 
-        result.finalize();
+        // We might get in a situation where something has been resolved but is not actually needed anymore
+        // because the package it was coming from has been replaced by a different version in the resolution.
+        let roots: HashSet<_> = dependencies.iter().map(|d| d.name()).collect();
+        result.finalize(&roots);
         result
     }
 }

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -46,7 +46,7 @@ impl<'d> Resolution<'d> {
         }
     }
 
-    pub fn finalize(&mut self) {
+    pub fn finalize(&mut self, roots: &HashSet<&str>) {
         // First we go through the failed dependencies to see if something that would match was found
         // (for example it can happen if someone puts a dep in a git package and specify that dep
         // directly in rproject.toml instead of remotes)
@@ -118,7 +118,27 @@ impl<'d> Resolution<'d> {
                     let keep = indices.contains(&current_idx);
                     current_idx += 1;
                     keep
-                })
+                });
+
+                // Some GC. We remove anything we can't reach from the roots + their suggests
+                let mut reachable: HashSet<String> = HashSet::new();
+                let mut stack: Vec<String> = roots.iter().map(|s| s.to_string()).collect();
+                while let Some(name) = stack.pop() {
+                    if !reachable.insert(name.clone()) {
+                        continue;
+                    }
+                    if let Some(pkg) = self.found.iter().find(|p| p.name.as_ref() == name) {
+                        for d in &pkg.dependencies {
+                            stack.push(d.name().to_string());
+                        }
+                        if pkg.install_suggests {
+                            for s in &pkg.suggests {
+                                stack.push(s.name().to_string());
+                            }
+                        }
+                    }
+                }
+                self.found.retain(|p| reachable.contains(p.name.as_ref()));
             }
             Err(req_errors) => {
                 let mut out = HashMap::new();

--- a/src/resolver/snapshots/rv__resolver__tests__transitive_new_suggests_dep.txt.snap
+++ b/src/resolver/snapshots/rv__resolver__tests__transitive_new_suggests_dep.txt.snap
@@ -1,0 +1,6 @@
+---
+source: src/resolver/mod.rs
+expression: out
+---
+suggestsB=1.0.0 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+suggestsA=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])

--- a/src/resolver/snapshots/rv__resolver__tests__transitive_new_suggests_dep.txt.snap
+++ b/src/resolver/snapshots/rv__resolver__tests__transitive_new_suggests_dep.txt.snap
@@ -4,3 +4,4 @@ expression: out
 ---
 suggestsB=1.0.0 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
 suggestsA=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+survival=2.1.1 (builtin, type=binary, path='', from_lockfile=false, from_remote=false, env_vars=[])

--- a/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
+++ b/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
@@ -3,7 +3,6 @@ source: src/resolver/mod.rs
 expression: out
 ---
 suggestsA=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
-suggestsC=1.0.0 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
 survival=2.1.1 (builtin, type=binary, path='', from_lockfile=false, from_remote=false, env_vars=[])
 suggestsB=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
 dummy=0.0.0.9001 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])

--- a/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
+++ b/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
@@ -6,3 +6,5 @@ suggestsA=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from
 suggestsC=1.0.0 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
 survival=2.1.1 (builtin, type=binary, path='', from_lockfile=false, from_remote=false, env_vars=[])
 suggestsB=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+dummy=0.0.0.9001 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+R6=2.5.1 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])

--- a/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
+++ b/src/resolver/snapshots/rv__resolver__tests__transitive_removed_suggests.txt.snap
@@ -1,0 +1,8 @@
+---
+source: src/resolver/mod.rs
+expression: out
+---
+suggestsA=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+suggestsC=1.0.0 (repository(url: http://test_repo1/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])
+survival=2.1.1 (builtin, type=binary, path='', from_lockfile=false, from_remote=false, env_vars=[])
+suggestsB=2.0.0 (repository(url: http://test_repo2/), type=source, path='', from_lockfile=false, from_remote=false, env_vars=[])

--- a/src/tests/package_files/test_repo1.PACKAGE
+++ b/src/tests/package_files/test_repo1.PACKAGE
@@ -4,6 +4,9 @@ Imports: R6
 License: MIT + file LICENSE
 MD5sum: b7f25d09ecab0c56f94f1238ddd604e6
 
+Package: R6
+Version: 2.5.1
+
 Package: rv.git.pkgA
 Version: 0.0.5
 License: MIT + file LICENSE

--- a/src/tests/package_files/test_repo1.PACKAGE
+++ b/src/tests/package_files/test_repo1.PACKAGE
@@ -29,3 +29,16 @@ Version: 6.0.0
 
 Package: test.force_source
 Version: 1.0.0
+
+Package: suggestsA
+Version: 1.0.0
+Suggests: suggestsB
+
+Package: suggestsB
+Version: 1.0.0
+Depends: suggestsA (>= 2.0.0)
+Suggests: suggestsC, survival
+
+Package: suggestsC
+Version: 1.0.0
+Depends: suggestsB (>= 2.0.0)

--- a/src/tests/package_files/test_repo2.PACKAGE
+++ b/src/tests/package_files/test_repo2.PACKAGE
@@ -12,3 +12,12 @@ MD5sum: ad2ae403ef70f3d622e4f7a6d51a3f2b
 Package: test.suggests
 Version: 1.0.0
 Suggests: rv.git.pkgA (>= 0.0.5)
+
+Package: suggestsA
+Version: 2.0.0
+Suggests: suggestsB, survival
+
+Package: suggestsB
+Version: 2.0.0
+Depends: suggestsA (>= 2.0.0)
+Suggests: dummy, survival

--- a/src/tests/resolution/transitive_new_suggests_dep.txt
+++ b/src/tests/resolution/transitive_new_suggests_dep.txt
@@ -1,0 +1,13 @@
+[project]
+name = "test"
+r_version = "4.4"
+repositories = []
+dependencies = [
+    { name = "suggestsA", install_suggestions = true }
+]
+---
+repos = [
+    { name = "test_repo1", source = "test_repo1", force_source = false },
+    { name = "test_repo2", source = "test_repo2", force_source = false }
+]
+---

--- a/src/tests/resolution/transitive_removed_suggests.txt
+++ b/src/tests/resolution/transitive_removed_suggests.txt
@@ -1,0 +1,13 @@
+[project]
+name = "test"
+r_version = "4.4"
+repositories = []
+dependencies = [
+    { name = "suggestsB", install_suggestions = true }
+]
+---
+repos = [
+    { name = "test_repo1", source = "test_repo1", force_source = false },
+    { name = "test_repo2", source = "test_repo2", force_source = false }
+]
+---


### PR DESCRIPTION
While working on the needs resolver, found a small resolution bug. QueueItems only ever get `install_suggestions = true` when they are derived from `ConfigDependency`, but if a `Suggests` changes for a different package version than the first resolved version, we never interact with it. I'm not completely sure how far deep we want to go into the rabbit hole, so this PR is just a place to start the discussion.

This PR has 2 examples:

### New Version = New Suggest

`suggestsA` has different suggested dependencies based on its version. The first pass resolution gets the suggests from the first repository and never revisits the actual source the package comes from, so we miss `survival` in the resolution.

This is the scenario I was first thought about and think the implementation would be fairly simple

### New Version = Dropped Suggest

This one is even weirder than I originally thought when I wrote it, but `suggestsB` has different suggests based on its version as well. The suggest on the first looked at version depends on a higher version of `suggestsB`, so we upgrade it to `2.0.0` which then loses that suggested dependency, but that is not reflected in the resolution

> This one gets infinite-loopy since if we remove `suggestsC`, then the requirement that `suggestsB >= 2.0.0` also is removed, then we add back in `suggestsC`, ...

To me, the simplest answer is we set `install_suggestions = true` for all `QueueItems` which are declared as such in the config and accept that the requirements may build to be more than required, but it is at least covering that the used package's suggests are actually covered, but interested in thoughts