### PR TITLE
No partial success for rv add

### DIFF
--- a/src/cli/resolution.rs
+++ b/src/cli/resolution.rs
@@ -1,7 +1,7 @@
 use crate::{Context, Resolution, ResolveMode};
 
 /// Resolve dependencies for the project. If there are any unmet dependencies, they will be printed
-/// to stderr and the cli will exit.
+/// to stderr and the cli may exit.
 pub fn resolve_dependencies(
     context: &Context,
     resolve_mode: ResolveMode,
@@ -10,17 +10,7 @@ pub fn resolve_dependencies(
     let resolution = context.resolve(resolve_mode);
 
     if !resolution.is_success() && exit_on_failure {
-        eprintln!("Failed to resolve all dependencies");
-        let req_error_messages = resolution.req_error_messages();
-
-        for d in &resolution.failed {
-            eprintln!("    {d}");
-        }
-
-        if !req_error_messages.is_empty() {
-            eprintln!("{}", req_error_messages.join("\n"));
-        }
-
+        resolution.print_failures();
         ::std::process::exit(1)
     }
 

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -68,6 +68,9 @@ impl SyncHelper {
         // TODO: exit on failure without println? and move that to main.rs
         // otherwise callers will think everything is fine
         let resolution = resolve_dependencies(context, resolve_mode, self.exit_on_failure);
+        if !resolution.is_success() {
+            return Ok(resolution);
+        }
 
         if self.locked {
             let new_lockfile =

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,14 +701,11 @@ fn try_main() -> Result<()> {
                 .map_err(|e| anyhow!("Invalid package spec: {e}"))?;
                 added.extend(add_packages(&mut doc, packages, resolved_options)?);
             }
-            // write the update if not dry run
-            if !dry_run {
-                write(&cli.config_file, doc.to_string())?;
-            }
-            print_add_summary(&output_format, &added, dry_run);
+
             let updated_config_toml = doc.to_string();
             // if no sync, exit early
             if no_sync {
+                print_add_summary(&output_format, &added, dry_run);
                 // no_sync means we should persist config edits immediately
                 if !dry_run {
                     write(&cli.config_file, &updated_config_toml)?;
@@ -726,17 +723,42 @@ fn try_main() -> Result<()> {
             context
                 .load_for_resolve_mode(resolve_mode)
                 .map_err(|e| anyhow!("{e}"))?;
+
             if !output_format.is_json() {
                 println!("\nResolving dependencies...");
             }
-            SyncHelper {
+
+            let sync_helper = SyncHelper {
                 dry_run,
-                output_format: Some(output_format),
+                output_format: Some(output_format.clone()),
+                exit_on_failure: false,
                 ..Default::default()
-            }
-            .run(&context, resolve_mode)?;
-            if !dry_run {
-                write(&cli.config_file, &updated_config_toml)?;
+            };
+
+            let print_aborted = || {
+                eprintln!("---");
+                eprintln!("The rproject.toml hasn't been modified.");
+            };
+
+            match sync_helper.run(&context, resolve_mode) {
+                Ok(resolution) => {
+                    if resolution.is_success() {
+                        print_add_summary(&output_format, &added, dry_run);
+                        if !dry_run {
+                            write(&cli.config_file, &updated_config_toml)?;
+                        }
+                    } else {
+                        resolution.print_failures();
+                        print_aborted();
+                        return Err(anyhow!(
+                            "One or more dependencies could not be resolved."
+                        ));
+                    }
+                }
+                Err(e) => {
+                    print_aborted();
+                    return Err(e);
+                }
             }
         }
         Command::Remove {

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,9 +750,7 @@ fn try_main() -> Result<()> {
                     } else {
                         resolution.print_failures();
                         print_aborted();
-                        return Err(anyhow!(
-                            "One or more dependencies could not be resolved."
-                        ));
+                        return Err(anyhow!("One or more dependencies could not be resolved."));
                     }
                 }
                 Err(e) => {

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -159,6 +159,20 @@ impl<'d> Resolution<'d> {
         self.failed.is_empty() && self.req_failures.is_empty()
     }
 
+    /// Print all resolution errors to stderr
+    pub fn print_failures(&self) {
+        eprintln!("Failed to resolve all dependencies");
+
+        for d in &self.failed {
+            eprintln!("    {d}");
+        }
+
+        let req_error_messages = self.req_error_messages();
+        if !req_error_messages.is_empty() {
+            eprintln!("{}", req_error_messages.join("\n"));
+        }
+    }
+
     pub fn req_error_messages(&self) -> Vec<String> {
         self.req_failures
             .iter()

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -27,7 +27,7 @@ dependencies = [
 #[ignore]
 fn test_add_failure_is_atomic() {
     let cache = TempDir::new().unwrap();
-    let (temp_dir, config_path) = create_test_project();
+    let (_temp_dir, config_path) = create_test_project();
     let original_config = fs::read_to_string(&config_path).unwrap();
 
     let mut cmd = cargo::cargo_bin_cmd!();
@@ -42,9 +42,6 @@ fn test_add_failure_is_atomic() {
     let output = cmd.output().unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    assert!(
-        stderr.contains("The rproject.toml hasn't been changed"),
-        "expected the no-change message on stderr.\nstderr:\n{stderr}"
-    );
+    assert!(stderr.contains("The rproject.toml hasn't been modified."),);
     assert_eq!(fs::read_to_string(&config_path).unwrap(), original_config,);
 }

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -1,0 +1,50 @@
+use assert_cmd::cargo;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Create a test project with a single, already-known dependency (R6) and a posit repo.
+fn create_test_project() -> (TempDir, PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("rproject.toml");
+
+    let config_content = r#"[project]
+name = "test"
+r_version = "4.5"
+repositories = [
+    {alias = "posit", url = "https://packagemanager.posit.co/cran/2024-12-16/"}
+]
+dependencies = [
+    "R6",
+]
+"#;
+
+    fs::write(&config_path, config_content).unwrap();
+    (temp_dir, config_path)
+}
+
+#[test]
+#[ignore]
+fn test_add_failure_is_atomic() {
+    let cache = TempDir::new().unwrap();
+    let (temp_dir, config_path) = create_test_project();
+    let original_config = fs::read_to_string(&config_path).unwrap();
+
+    let mut cmd = cargo::cargo_bin_cmd!();
+    cmd.env("RV_CACHE_DIR", cache.path()).args([
+        "--config-file",
+        config_path.to_str().unwrap(),
+        "add",
+        "jsonlite",
+        "rv-no-such-package-xyz",
+    ]);
+
+    let output = cmd.output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("The rproject.toml hasn't been changed"),
+        "expected the no-change message on stderr.\nstderr:\n{stderr}"
+    );
+    assert_eq!(fs::read_to_string(&config_path).unwrap(), original_config,);
+}


### PR DESCRIPTION
Closes #482

```
 cargo run --all-features -- -c example_projects/test/rproject.toml add R6 whateverweqweqwe
   Compiling rv v0.21.0 (/home/vincent/Code/a2-ai/rv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.59s
     Running `target/debug/rv -c example_projects/test/rproject.toml add R6 whateverweqweqwe`

Resolving dependencies...
Failed to resolve all dependencies
    R6 [listed in rproject.toml]
    whateverweqweqwe [listed in rproject.toml]
---
The rproject.toml hasn't been modified.
One or more dependencies could not be resolved.
```