### PR TITLE
feat: cache url sources locally and read from global cache

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -4,6 +4,7 @@ mod status;
 pub mod utils;
 
 use crate::cache::utils::get_global_cache_dir;
+use crate::fs::copy_folder;
 use crate::package::Package;
 use crate::system_req::SysReqError;
 use crate::{RInstall, Source, SystemInfo, Version};
@@ -12,7 +13,8 @@ pub use info::CacheInfo;
 pub use status::{CacheStatus, InstallationStatus};
 use std::collections::HashMap;
 use std::error::Error;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use url::Url;
 
 #[derive(Debug)]
 pub struct Cache {
@@ -115,5 +117,43 @@ impl Cache {
             .as_ref()
             .map(|x| x.get_package_paths(source, pkg_name, version));
         (local, global)
+    }
+
+    /// Try to locate a URL source in the local cache. If it is only present in the global cache,
+    /// copy it to the local cache first. Returns `Ok(None)` if the source is not available
+    /// anywhere, or an I/O error if copying from the global cache fails.
+    pub(crate) fn get_url_source_path(
+        &self,
+        url: &Url,
+        sha: &str,
+    ) -> std::io::Result<Option<PathBuf>> {
+        let local_path = self.local.get_url_download_path(url).join(&sha[..10]);
+        if local_path.is_dir() {
+            return Ok(Some(local_path));
+        }
+
+        if let Some(global) = self.global.as_ref() {
+            let global_path = global.get_url_download_path(url).join(&sha[..10]);
+            if global_path.is_dir() {
+                log::debug!(
+                    "Copying URL source from global cache at {} to local cache at {}",
+                    global_path.display(),
+                    local_path.display()
+                );
+                fs_err::create_dir_all(&local_path)?;
+                copy_folder(&global_path, &local_path)?;
+                return Ok(Some(local_path));
+            }
+        }
+
+        Ok(None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_global_cache(local: DiskCache, global: DiskCache) -> Self {
+        Self {
+            local,
+            global: Some(global),
+        }
     }
 }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -421,10 +421,35 @@ impl<'d> Resolver<'d> {
         cache: &'d Cache,
         http_downloader: &'d impl HttpDownload,
     ) -> Result<(ResolvedDependency<'d>, Vec<QueueItem<'d>>), Box<dyn std::error::Error>> {
-        let out_path = cache.local().get_url_download_path(url);
-        let (dir, sha) = http_downloader.download_and_untar(url, &out_path, true, None)?;
+        // If we have a lockfile entry for this URL package, try to use its SHA to find a
+        // cached source before downloading. The SHA is the content hash, so a cached source
+        // with that SHA is reproducible.
+        let lockfile_sha = self
+            .lockfile
+            .and_then(|l| l.get_package(&item.name, item.dep))
+            .and_then(|p| match &p.source {
+                Source::Url { sha, .. } => Some(sha.clone()),
+                _ => None,
+            });
 
-        let install_path = dir.unwrap_or_else(|| out_path.clone());
+        let out_path = cache.local().get_url_download_path(url);
+        let (install_path, sha) = if let Some(sha) = lockfile_sha {
+            if let Some(cached_source) = cache.get_url_source_path(url, &sha)? {
+                log::debug!(
+                    "Using cached URL source for {} from {}",
+                    item.name,
+                    cached_source.display()
+                );
+                (cached_source, sha)
+            } else {
+                let (dir, sha) = http_downloader.download_and_untar(url, &out_path, true, None)?;
+                (dir.unwrap_or_else(|| out_path.clone()), sha)
+            }
+        } else {
+            let (dir, sha) = http_downloader.download_and_untar(url, &out_path, true, None)?;
+            (dir.unwrap_or_else(|| out_path.clone()), sha)
+        };
+
         let package = parse_description_file_in_folder(&install_path)?;
         if item.name != package.name {
             return Err(format!(
@@ -768,6 +793,7 @@ mod tests {
     use serde::Deserialize;
     use tempfile::TempDir;
 
+    use crate::DiskCache;
     use crate::SystemInfo;
     use crate::config::Config;
     use crate::consts::{BASE_PACKAGES, DESCRIPTION_FILENAME};
@@ -1012,5 +1038,134 @@ mod tests {
             // Output has been compared with pkgr for the same PACKAGE file
             insta::assert_snapshot!(p.file_name().unwrap().to_string_lossy().to_string(), out);
         }
+    }
+
+    struct TrackedHttp {
+        called: std::sync::atomic::AtomicBool,
+    }
+
+    impl HttpDownload for TrackedHttp {
+        fn download<W: Write>(
+            &self,
+            _: &Url,
+            _: &mut W,
+            _: Vec<(&str, String)>,
+        ) -> Result<u64, HttpError> {
+            Ok(0)
+        }
+
+        fn download_and_untar(
+            &self,
+            _: &Url,
+            _: impl AsRef<Path>,
+            _: bool,
+            _: Option<&Path>,
+        ) -> Result<(Option<PathBuf>, String), HttpError> {
+            self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok((None, "SOME_SHA".to_string()))
+        }
+    }
+
+    #[test]
+    fn url_source_from_global_cache_avoids_download() {
+        let url = "https://example.com/dplyr_1.1.3.tar.gz";
+        let sha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let _url_parsed = Url::parse(url).unwrap();
+
+        let local_dir = tempfile::tempdir().unwrap();
+        let global_dir = tempfile::tempdir().unwrap();
+        let local_cache = DiskCache::new_in_dir(
+            &Version::from_str("4.5.0").unwrap(),
+            SystemInfo::from_os_info(),
+            local_dir.path(),
+        )
+        .unwrap();
+        let global_cache = DiskCache::new_in_dir(
+            &Version::from_str("4.5.0").unwrap(),
+            SystemInfo::from_os_info(),
+            global_dir.path(),
+        )
+        .unwrap();
+        let cache = Cache::with_global_cache(local_cache, global_cache);
+
+        // Seed the global cache with the URL source
+        let global_source = global_dir
+            .path()
+            .join("urls")
+            .join(crate::cache::utils::hash_string(url))
+            .join(&sha[..10])
+            .join("dplyr");
+        fs::create_dir_all(&global_source).unwrap();
+        fs::write(
+            global_source.join(DESCRIPTION_FILENAME),
+            "Package: dplyr\nVersion: 1.1.3\n",
+        )
+        .unwrap();
+
+        let local_source = local_dir
+            .path()
+            .join("urls")
+            .join(crate::cache::utils::hash_string(url))
+            .join(&sha[..10])
+            .join("dplyr");
+
+        let config = Config::from_str(&format!(
+            r#"[project]
+name = "test"
+r_version = "4.5"
+repositories = []
+dependencies = [
+    {{ name = "dplyr", url = "{url}" }}
+]
+"#
+        ))
+        .unwrap();
+
+        let lockfile = Lockfile::from_str(&format!(
+            r#"version = 2
+r_version = "4.5"
+[[packages]]
+name = "dplyr"
+version = "1.1.3"
+source = {{ url = "{url}", sha = "{sha}" }}
+force_source = false
+dependencies = []
+"#
+        ))
+        .unwrap();
+
+        let r_version = Version::from_str("4.5.0").unwrap();
+        let builtin_packages = HashMap::new();
+        let resolver = Resolver::new(
+            Path::new("."),
+            &[],
+            HashSet::new(),
+            &r_version,
+            &builtin_packages,
+            Some(&lockfile),
+            config.packages_env_vars(),
+        );
+
+        let http = TrackedHttp {
+            called: std::sync::atomic::AtomicBool::new(false),
+        };
+        let _resolution = resolver.resolve(
+            config.dependencies(),
+            config.prefer_repositories_for(),
+            &cache,
+            &FakeGit {},
+            &http,
+        );
+
+        assert!(
+            !http.called.load(std::sync::atomic::Ordering::SeqCst),
+            "download_and_untar should not be called when the URL source is in the cache"
+        );
+
+        // The source should have been copied from the global cache into the local cache
+        assert!(
+            local_source.is_dir(),
+            "URL source should have been copied from global cache to local cache"
+        );
     }
 }

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -373,7 +373,7 @@ impl<'a> SyncHandler<'a> {
             Source::Url { .. } => sources::url::install_package(
                 dep,
                 &library_dirs,
-                self.context.cache.local(),
+                &self.context.cache,
                 r_cmd,
                 &configure_args,
                 strip,

--- a/src/sync/sources/url.rs
+++ b/src/sync/sources/url.rs
@@ -4,37 +4,51 @@ use std::sync::Arc;
 
 use fs_err as fs;
 
+use crate::cache::Cache;
 use crate::events;
 use crate::library::LocalMetadata;
+use crate::lockfile::Source;
 use crate::package::PackageType;
 use crate::sync::LinkMode;
 use crate::sync::errors::SyncError;
-use crate::{Cancellation, DiskCache, RCmd, ResolvedDependency};
+use crate::{Cancellation, RCmd, ResolvedDependency};
 
 pub(crate) fn install_package(
     pkg: &ResolvedDependency,
     library_dirs: &[&Path],
-    cache: &DiskCache,
+    cache: &Cache,
     r_cmd: &impl RCmd,
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
 ) -> Result<(), SyncError> {
-    let pkg_paths = cache.get_package_paths(&pkg.source, None, None);
-    let download_path = pkg_paths.source.join(pkg.name.as_ref());
+    let (local_paths, global_paths) = cache.get_package_paths(&pkg.source, None, None);
 
-    // If we have a binary, copy it since we don't keep cache around for binary URL packages
+    // Prefer the local source, but copy from the global cache to the local cache if needed.
+    // Resolution normally populates the local cache, but the global cache may have been seeded
+    // externally and we avoid building directly against the read-only global cache.
+    let (url, sha) = match &pkg.source {
+        Source::Url { url, sha } => (url, sha),
+        _ => unreachable!("install_package called with non-URL source"),
+    };
+    let source_path = cache
+        .get_url_source_path(url, sha)?
+        .unwrap_or(local_paths.source);
+    let download_path = source_path.join(pkg.name.as_ref());
+
+    // If the downloaded URL archive is already a binary package, copy it into the local binary
+    // cache path unless we already have a usable binary (locally or globally).
     if pkg.kind == PackageType::Binary {
         log::debug!(
             "Package from URL in {} is already a binary",
             download_path.display()
         );
-        if !pkg_paths.binary.is_dir() {
+        if !pkg.cache_status.binary_available() {
             LinkMode::link_files(
                 Some(LinkMode::Copy),
                 &pkg.name,
-                &pkg_paths.source,
-                &pkg_paths.binary,
+                &source_path,
+                &local_paths.binary,
             )?;
         }
     } else {
@@ -47,7 +61,7 @@ pub(crate) fn install_package(
                 &download_path,
                 Option::<&Path>::None,
                 library_dirs,
-                &pkg_paths.binary,
+                &local_paths.binary,
                 cancellation,
                 &pkg.env_vars,
                 configure_args,
@@ -55,7 +69,7 @@ pub(crate) fn install_package(
             )
         })?;
 
-        let log_path = cache.get_build_log_path(&pkg.source, None, None);
+        let log_path = cache.local().get_build_log_path(&pkg.source, None, None);
         if let Some(parent) = log_path.parent() {
             fs::create_dir_all(parent)?;
             let mut f = fs::File::create(log_path)?;
@@ -63,16 +77,22 @@ pub(crate) fn install_package(
         }
     }
 
-    let metadata = LocalMetadata::Sha(pkg.source.sha().to_owned());
-    metadata.write(pkg_paths.binary.join(pkg.name.as_ref()))?;
+    // Only write metadata to the local binary cache; the global cache is read-only and its
+    // binaries are assumed to already contain the correct metadata.
+    if !pkg.cache_status.global_binary_available() {
+        let metadata = LocalMetadata::Sha(pkg.source.sha().to_owned());
+        metadata.write(local_paths.binary.join(pkg.name.as_ref()))?;
+    }
+
+    // Link from the global cache if a binary is available there, otherwise from the local cache.
+    let binary_path = if pkg.cache_status.global_binary_available() {
+        global_paths.unwrap().binary
+    } else {
+        local_paths.binary
+    };
 
     // And then we always link the binary folder into the staging library
-    LinkMode::link_files(
-        None,
-        &pkg.name,
-        &pkg_paths.binary,
-        library_dirs.first().unwrap(),
-    )?;
+    LinkMode::link_files(None, &pkg.name, &binary_path, library_dirs.first().unwrap())?;
 
     Ok(())
 }


### PR DESCRIPTION
This makes URL dependencies reusable across resolves without re-downloading, and lets them benefit from a pre-populated global cache.

Changes:

- `Resolver::url_lookup` checks the local URL cache by SHA before downloading. If the source is only in the global cache, it is copied to the local cache.
- `Cache::get_url_source_path` centralizes the local/global lookup and copy.
- `sync/sources/url.rs` receives the full Cache, copies global sources to local when needed, and links binaries from the global cache if present.
- Added a resolver test verifying that a cached URL source skips the HTTP download.

The global cache remains read-only.