### PR TITLE
Invoke Rscript.exe directly instead of via .bat shim (#488, #489)

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -109,16 +109,27 @@ fn render_config(
 }
 
 pub fn find_r_repositories() -> Result<Vec<Repository>, InitError> {
-    let r_code = r#"
-    repos <- getOption("repos")
-    cat(paste(names(repos), repos, sep = "\t", collapse = "\n"))
-    "#;
+    // Resolve Rscript from the R on PATH via its R_HOME rather than spawning a bare
+    // `Rscript`. On Windows a bare name never resolves a rig `Rscript.bat` shim (Rust's
+    // `Command` ignores `PATHEXT`), and spawning the `.bat` itself routes through cmd.exe.
+    // `get_r_from_path` is `.bat`-aware, and the resolved `Rscript.exe` runs directly (#489).
+    let r_install = crate::r_finder::get_r_from_path().ok_or(InitError {
+        source: InitErrorKind::RNotFound,
+    })?;
+    let r_home = crate::r_cmd::get_r_home(&r_install.bin_path).map_err(|e| InitError {
+        source: InitErrorKind::Command(e),
+    })?;
+    let rscript = crate::r_cmd::resolve_rscript_path(&r_home);
+
+    // Keep this a single line with no embedded newlines: on Windows, Rscript.exe's
+    // front-end re-parses the `-e` argument and a multi-line value crashes it (#489).
+    let r_code = r#"repos <- getOption("repos"); cat(paste(names(repos), repos, sep = "\t", collapse = "\n"))"#;
 
     let (mut recv, send) = std::io::pipe().map_err(|e| InitError {
         source: InitErrorKind::Command(e),
     })?;
 
-    let mut command = Command::new("Rscript");
+    let mut command = Command::new(&rscript);
     command
         .arg("-e")
         .arg(r_code)
@@ -216,6 +227,8 @@ pub enum InitErrorKind {
     Io(#[from] std::io::Error),
     #[error("R command failed: {0}")]
     Command(std::io::Error),
+    #[error("Could not find R on PATH")]
+    RNotFound,
     #[error("Failed to find repositories: {0}")]
     CommandFailed(String),
 }

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -545,10 +545,48 @@ pub(crate) fn get_r_home(r_bin_path: &Path) -> Result<PathBuf, std::io::Error> {
     Ok(PathBuf::from(r_home))
 }
 
+/// Resolve the `Rscript` inside an R installation tree from its `R_HOME`.
+///
+/// The R tree always ships `Rscript.exe` on Windows, never a `.bat`. We deliberately do
+/// not reuse the extension of the `R` binary rv was launched with, nor invoke `Rscript`
+/// off PATH: when R is found via a rig `.bat` shim (e.g. `R.bat`), the former derives a
+/// nonexistent `{R_HOME}/bin/Rscript.bat` (#488), and spawning a `.bat` shim routes
+/// through cmd.exe, which mangles multi-line `-e` scripts (#489). `R_HOME` already points
+/// at the real install tree, so the sibling `Rscript.exe`, invoked directly, always works.
+pub(crate) fn resolve_rscript_path(r_home: &Path) -> PathBuf {
+    let mut rscript = r_home.join("bin").join("Rscript");
+
+    if cfg!(windows) {
+        rscript.set_extension("exe");
+    }
+
+    rscript
+}
+
 #[cfg(test)]
 mod tests {
-    use super::find_r_version;
+    use super::{find_r_version, resolve_rscript_path};
     use crate::Version;
+    use std::path::PathBuf;
+
+    #[test]
+    fn resolve_rscript_from_r_home() {
+        let r_home = PathBuf::from("/opt/R/4.5.0/lib/R");
+
+        #[cfg(not(windows))]
+        assert_eq!(
+            resolve_rscript_path(&r_home),
+            r_home.join("bin").join("Rscript")
+        );
+
+        // On Windows the R tree only ships Rscript.exe, so we always target that,
+        // regardless of how R itself was located (e.g. a rig `R.bat` shim, #488/#489).
+        #[cfg(windows)]
+        assert_eq!(
+            resolve_rscript_path(&r_home),
+            r_home.join("bin").join("Rscript.exe")
+        );
+    }
 
     #[test]
     fn can_read_r_version() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,7 @@ pub fn run(r_bin_path: &Path, library_path: &Path, args: &[String]) -> Result<i3
         path: r_bin_path.to_path_buf(),
         source,
     })?;
-    let rscript = resolve_rscript_path(&r_home, r_bin_path);
+    let rscript = crate::r_cmd::resolve_rscript_path(&r_home);
 
     let mut cmd = std::process::Command::new(&rscript);
     cmd.args(args)
@@ -33,20 +33,6 @@ pub fn run(r_bin_path: &Path, library_path: &Path, args: &[String]) -> Result<i3
     Ok(status.code().unwrap_or(1))
 }
 
-fn resolve_rscript_path(r_home: &Path, r_bin_path: &Path) -> PathBuf {
-    let mut rscript = r_home.join("bin").join("Rscript");
-
-    if cfg!(windows) {
-        if let Some(ext) = r_bin_path.extension() {
-            rscript.set_extension(ext);
-        } else {
-            rscript.set_extension("exe");
-        }
-    }
-
-    rscript
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum RunError {
     #[error("Failed to run Rscript at {path}: {source}")]
@@ -59,28 +45,4 @@ pub enum RunError {
         path: PathBuf,
         source: std::io::Error,
     },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolve_rscript_path;
-    use std::path::PathBuf;
-
-    #[test]
-    fn resolve_rscript_from_r_home_when_r_has_no_parent() {
-        let r_home = PathBuf::from("/opt/R/4.5.0/lib/R");
-        let r_bin_path = PathBuf::from("R");
-
-        #[cfg(not(windows))]
-        assert_eq!(
-            resolve_rscript_path(&r_home, &r_bin_path),
-            r_home.join("bin").join("Rscript")
-        );
-
-        #[cfg(windows)]
-        assert_eq!(
-            resolve_rscript_path(&r_home, &r_bin_path),
-            r_home.join("bin").join("Rscript.exe")
-        );
-    }
 }


### PR DESCRIPTION
Fixes #488 and #489.