### PR TITLE
Isolate git tests from the machine's git configuration

### DIFF
--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -407,22 +407,7 @@ fn fetch_with_cli(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::git::GitExecutor;
-    use std::process::Command;
-
-    fn run_git(args: &[&str], dir: &Path) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use crate::git::test_support::{IsolatedGitExecutor, run_git};
 
     fn setup_test_repo() -> (tempfile::TempDir, String) {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -436,8 +421,6 @@ mod tests {
         // Clone and setup working repo
         std::fs::create_dir_all(&work_path).unwrap();
         run_git(&["clone", remote_path.to_str().unwrap(), "."], &work_path);
-        run_git(&["config", "user.email", "test@example.com"], &work_path);
-        run_git(&["config", "user.name", "Test User"], &work_path);
 
         // Create initial commit
         std::fs::write(work_path.join("file.txt"), "initial content").unwrap();
@@ -460,8 +443,12 @@ mod tests {
         let cache_path = temp_dir.path().join("cache");
         let work_path = temp_dir.path().join("work");
 
-        let repo =
-            GitRepository::init(&cache_path, remote_path.to_str().unwrap(), GitExecutor).unwrap();
+        let repo = GitRepository::init(
+            &cache_path,
+            remote_path.to_str().unwrap(),
+            IsolatedGitExecutor,
+        )
+        .unwrap();
 
         // First fetch
         repo.fetch(
@@ -504,8 +491,12 @@ mod tests {
         run_git(&["tag", "v1.0"], &work_path);
         run_git(&["push", "origin", "v1.0"], &work_path);
 
-        let repo =
-            GitRepository::init(&cache_path, remote_path.to_str().unwrap(), GitExecutor).unwrap();
+        let repo = GitRepository::init(
+            &cache_path,
+            remote_path.to_str().unwrap(),
+            IsolatedGitExecutor,
+        )
+        .unwrap();
 
         // First fetch
         repo.fetch(remote_path.to_str().unwrap(), &GitReference::Tag("v1.0"))

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,6 +4,8 @@ use std::process::Command;
 mod local;
 mod reference;
 mod remote;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod url;
 
 pub trait CommandExecutor {

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -1,0 +1,74 @@
+//! Test-only helpers to run `git` without picking up the machine's git configuration.
+//!
+//! The tests build throwaway repositories, so whatever config the machine carries changes what
+//! those commands do: `tag.gpgSign` alone turns the lightweight `git tag v1.0` into an annotated
+//! tag, which then fails with `fatal: no tag message?`.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::git::{CommandExecutor, GitExecutor};
+
+const TEST_USER_NAME: &str = "Test User";
+const TEST_USER_EMAIL: &str = "test@example.com";
+
+/// Makes a git command ignore the machine's configuration and environment.
+pub(crate) fn isolate_git_env(command: &mut Command) -> &mut Command {
+    // No `HOME`/`XDG_CONFIG_HOME` means no global config, attributes or ignore file, and no
+    // `GIT_*` from the surrounding shell either: `GIT_DIR` would point the fixtures at another
+    // repository outright.
+    command.env_clear();
+
+    // Not for the spawn itself, which finds git either way: a cleared PATH falls back to a system
+    // default, and on the macOS CI runner that quietly swaps the Homebrew git for the older Apple
+    // one inside Xcode. PATH cannot affect git's configuration.
+    //
+    // NOTE: On Windows most environmental variables used by an msys2 binary like Git for Windows
+    // (SystemDrive, WINDIR, TEMP, TMP, COMSPEC, PATHEXT) are not needed for any of the fixtures
+    // (bare init, clone, add, commit, push, tag, fetch). However, a test that fetches over the
+    // network would need SystemRoot back on Windows.
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+
+    command
+        // The system config is found by compiled-in path, so `env_clear` does not hide it
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_ATTR_NOSYSTEM", "1")
+        // Without a global config there is no user.name/user.email to commit or tag with
+        .env("GIT_AUTHOR_NAME", TEST_USER_NAME)
+        .env("GIT_AUTHOR_EMAIL", TEST_USER_EMAIL)
+        .env("GIT_COMMITTER_NAME", TEST_USER_NAME)
+        .env("GIT_COMMITTER_EMAIL", TEST_USER_EMAIL)
+        // No credential prompts: a test that blocks on one never finishes
+        .env("GIT_TERMINAL_PROMPT", "0")
+}
+
+/// The [`GitExecutor`] rv uses in production, with the isolation applied to every command.
+///
+/// It lands after the calling code has built its command, so the `env_clear` drops whatever
+/// environment that code set up. Anything the production commands grow beyond what
+/// [`isolate_git_env`] puts back needs mirroring there.
+#[derive(Debug, Clone)]
+pub(crate) struct IsolatedGitExecutor;
+
+impl CommandExecutor for IsolatedGitExecutor {
+    fn execute(&self, command: &mut Command) -> Result<String, std::io::Error> {
+        GitExecutor.execute(isolate_git_env(command))
+    }
+}
+
+/// Runs an isolated git command in `dir` to set up a test fixture, panicking if it fails so that
+/// no test passes on the empty output of a command that did not run.
+pub(crate) fn run_git(args: &[&str], dir: &Path) {
+    let mut command = Command::new("git");
+    command.args(args).current_dir(dir);
+
+    let output = isolate_git_env(&mut command).output().unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
The tests in `src/git/local.rs` build throwaway repositories by shelling out to the `git` CLI, and git reads its regular config files. CI has no user config, so it stays green but on a contributor's machine, ordinary settings change what those commands do. A few examples:

- `tag.gpgSign`: lightweight tag becomes annotated → `fatal: no tag message?` (this is the one that I actually ran into)
- `commit.gpgSign`: every fixture commit waits on a signing key
- `core.autocrlf`: rewrites the file contents the tests assert on
- `url.<base>.insteadOf`: rewrites the fixture's remote paths
- `core.hooksPath`, `init.templateDir`: runs the developer's hooks in the fixture repos
- `filter.*`, `fetch.prune`, `push.*`, `credential.helper`: assorted behaviour changes
- `includeIf.*`: pulls in whole config files we never see

Instead of enumerating such settings, this PR suggests a more comprehensive isolation approach by adding a `#[cfg(test)]` module holding the isolation in one place, and routing every git invocation in the test suite through it.

## Not included

`tests/cli_global_cache.rs` drives the rv binary against a real GitHub git dependency and is left alone. Blanking global and system config there would also drop `http.proxy`, `http.sslCAInfo` and Git for Windows' system-level `http.sslBackend=schannel`, so isolation could break that test for developers behind a corporate network.