### PR TITLE
Use url content in local cache when possible

### DIFF
--- a/.github/scripts/integration.py
+++ b/.github/scripts/integration.py
@@ -4,7 +4,7 @@ import subprocess
 import shutil
 
 PARENT_FOLDER = "example_projects"
-SKIP_PLAN_CHECK = ["no-lockfile", "url", "custom-lib-path", "local-deps-depends-only"]
+SKIP_PLAN_CHECK = ["no-lockfile", "custom-lib-path", "local-deps-depends-only"]
 
 def run_cmd(cmd, path, json = False):
     print(f">> Running rv {cmd}")

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -18,6 +18,12 @@ use crate::package::{BuiltinPackages, Package, get_builtin_versions_from_library
 use crate::system_req::{SysReqError, get_system_requirements};
 use crate::{RInstall, SystemInfo, Version};
 
+/// We potentially use the SHA from the lockfile which can edited by hand so
+/// we don't do `[..10]` to avoid panics in that case
+fn sha_prefix(sha: &str) -> &str {
+    sha.get(..10).unwrap_or(sha)
+}
+
 #[derive(Debug, Clone)]
 pub struct PackagePaths {
     pub binary: PathBuf,
@@ -203,15 +209,21 @@ impl DiskCache {
         match source {
             Source::Git { git, sha, .. } => PackagePaths {
                 source: self.get_git_clone_path(git.url()),
-                binary: self.get_repo_root_binary_dir(git.url()).join(&sha[..10]),
+                binary: self
+                    .get_repo_root_binary_dir(git.url())
+                    .join(sha_prefix(sha)),
             },
             Source::RUniverse { git, sha, .. } => PackagePaths {
                 source: self.get_git_clone_path(git.url()),
-                binary: self.get_repo_root_binary_dir(git.url()).join(&sha[..10]),
+                binary: self
+                    .get_repo_root_binary_dir(git.url())
+                    .join(sha_prefix(sha)),
             },
             Source::Url { url, sha } => PackagePaths {
-                source: self.get_url_download_path(url).join(&sha[..10]),
-                binary: self.get_repo_root_binary_dir(url.as_str()).join(&sha[..10]),
+                source: self.get_url_download_path(url).join(sha_prefix(sha)),
+                binary: self
+                    .get_repo_root_binary_dir(url.as_str())
+                    .join(sha_prefix(sha)),
             },
             Source::Repository { repository } => {
                 let name = pkg_name.unwrap();

--- a/src/http.rs
+++ b/src/http.rs
@@ -238,13 +238,29 @@ impl HttpDownload for Http {
             let sha = sha.unwrap();
             let new_destination = destination.join(&sha[..10]);
             let install_dir = new_destination.join(actual_dir.file_name().unwrap());
-            if install_dir.is_dir() {
-                fs::remove_dir_all(&install_dir)
+
+            // atomic renames since we use the sha in the directory, and an error happening
+            // there is not fixable without cleaning the cache
+            fs::create_dir_all(&destination).map_err(|e| HttpError::from_io(url.as_str(), e))?;
+            let staging = tempfile::tempdir_in(&destination)
+                .map_err(|e| HttpError::from_io(url.as_str(), e))?;
+            copy_folder(
+                &actual_dir,
+                staging.path().join(actual_dir.file_name().unwrap()),
+            )
+            .map_err(|e| HttpError::from_io(url.as_str(), e))?;
+
+            if new_destination.is_dir() {
+                fs::remove_dir_all(&new_destination)
                     .map_err(|e| HttpError::from_io(url.as_str(), e))?;
             }
-            fs::create_dir_all(&install_dir).map_err(|e| HttpError::from_io(url.as_str(), e))?;
-            copy_folder(&actual_dir, &install_dir)
-                .map_err(|e| HttpError::from_io(url.as_str(), e))?;
+            let staging = staging.keep();
+            if let Err(e) = fs::rename(&staging, &new_destination) {
+                let _ = fs::remove_dir_all(&staging);
+                if !new_destination.is_dir() {
+                    return Err(HttpError::from_io(url.as_str(), e));
+                }
+            }
 
             (new_destination, Some(install_dir), sha)
         } else {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -122,6 +122,10 @@ impl Source {
         )
     }
 
+    pub fn is_url(&self) -> bool {
+        matches!(self, Source::Url { .. })
+    }
+
     pub fn is_repo(&self) -> bool {
         matches!(self, Source::Repository { .. })
     }

--- a/src/resolver/dependency.rs
+++ b/src/resolver/dependency.rs
@@ -211,6 +211,7 @@ impl<'d> ResolvedDependency<'d> {
         kind: PackageType,
         source: Source,
         install_suggests: bool,
+        cache_status: CacheStatus,
     ) -> (Self, InstallationDependencies<'_>) {
         let deps = package.dependencies_to_install(install_suggests);
         let res = Self {
@@ -227,7 +228,7 @@ impl<'d> ResolvedDependency<'d> {
             name: Cow::Owned(package.name.clone()),
             version: Cow::Owned(package.version.clone()),
             source,
-            cache_status: CacheStatus::new_local_source(),
+            cache_status,
             install_suggests,
             remotes: package.remotes.clone(),
             from_remote: false,

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -39,6 +39,8 @@ pub(crate) struct QueueItem<'d> {
     // Only for top level dependencies. Checks whether the config dependency is matching
     // what we have in the lockfile, we have one.
     matching_in_lockfile: Option<bool>,
+    // Only for top level URL dependencies with a matching lockfile entry: the sha of the tarball
+    locked_sha: Option<&'d str>,
 }
 
 impl<'d> QueueItem<'d> {
@@ -202,10 +204,19 @@ impl<'d> Resolver<'d> {
             .lockfile
             .and_then(|l| l.get_package(&item.name, item.dep))
         {
+            let status =
+                cache.get_installation_status(&item.name, &package.version, &package.source);
+
             // For some type of packages we will always refresh directly from the source
-            // eg a branch might have added commits
+            // eg a branch might have added commits.
             if package.source.could_have_changed() {
-                return None;
+                // For a URL the content might have changed but if we have the tarball sha in the cache,
+                // we will use it what's available already.
+                let pinned_and_cached = package.source.is_url()
+                    && (status.local.source_available() || status.binary_available());
+                if !pinned_and_cached {
+                    return None;
+                }
             }
 
             if let Some(req) = &item.version_requirement
@@ -213,9 +224,6 @@ impl<'d> Resolver<'d> {
             {
                 return None;
             }
-
-            let installation_status =
-                cache.get_installation_status(&item.name, &package.version, &package.source);
 
             // We search first in the repo for whether we have source or binary since
             // we don't record that info in the lockfile
@@ -263,8 +271,7 @@ impl<'d> Resolver<'d> {
                 // url/git/local are probably source packages
                 PackageType::Source
             };
-            let resolved_dep =
-                ResolvedDependency::from_locked_package(package, installation_status, kind);
+            let resolved_dep = ResolvedDependency::from_locked_package(package, status, kind);
 
             let items = package
                 .dependencies
@@ -423,6 +430,14 @@ impl<'d> Resolver<'d> {
     ) -> Result<(ResolvedDependency<'d>, Vec<QueueItem<'d>>), Box<dyn std::error::Error>> {
         let out_path = cache.local().get_url_download_path(url);
         let (dir, sha) = http_downloader.download_and_untar(url, &out_path, true, None)?;
+        if let Some(locked_sha) = item.locked_sha
+            && locked_sha != sha
+        {
+            return Err(format!(
+                "The URL {url} has different content than what is recorded in the lockfile (checksum mismatch). \
+                Run `rv upgrade` to accept the new content and update the lockfile."
+            ).into());
+        }
 
         let install_path = dir.unwrap_or_else(|| out_path.clone());
         let package = parse_description_file_in_folder(&install_path)?;
@@ -434,6 +449,12 @@ impl<'d> Resolver<'d> {
             .into());
         }
         let is_binary = is_binary_package(&install_path, &package.name)?;
+        let source = Source::Url {
+            url: url.clone(),
+            sha,
+        };
+        let status =
+            cache.get_installation_status(&package.name, &package.version.original, &source);
         let (resolved_dep, deps) = ResolvedDependency::from_url_package(
             &package,
             if is_binary {
@@ -441,11 +462,9 @@ impl<'d> Resolver<'d> {
             } else {
                 PackageType::Source
             },
-            Source::Url {
-                url: url.clone(),
-                sha,
-            },
+            source,
             item.install_suggestions,
+            status,
         );
         Ok(prepare_deps!(resolved_dep, deps, item.matching_in_lockfile))
     }
@@ -511,19 +530,23 @@ impl<'d> Resolver<'d> {
 
         let mut queue: VecDeque<_> = dependencies
             .iter()
-            .map(|d| QueueItem {
-                name: Cow::Borrowed(d.name()),
-                dep: Some(d),
-                version_requirement: None,
-                install_suggestions: d.install_suggestions(),
-                force_source: d.force_source(),
-                parent: None,
-                remote: None,
-                local_path: d.local_path(),
-                matching_in_lockfile: self.lockfile.and_then(|l| {
-                    l.get_package(d.name(), Some(d))
-                        .map(|p| p.is_matching(d, &self.repo_urls))
-                }),
+            .map(|d| {
+                let locked = self.lockfile.and_then(|l| l.get_package(d.name(), Some(d)));
+                QueueItem {
+                    name: Cow::Borrowed(d.name()),
+                    dep: Some(d),
+                    version_requirement: None,
+                    install_suggestions: d.install_suggestions(),
+                    force_source: d.force_source(),
+                    parent: None,
+                    remote: None,
+                    local_path: d.local_path(),
+                    matching_in_lockfile: locked.map(|p| p.is_matching(d, &self.repo_urls)),
+                    locked_sha: locked.and_then(|p| match &p.source {
+                        Source::Url { sha, .. } => Some(sha.as_str()),
+                        _ => None,
+                    }),
+                }
             })
             .collect();
 

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -373,7 +373,7 @@ impl<'a> SyncHandler<'a> {
             Source::Url { .. } => sources::url::install_package(
                 dep,
                 &library_dirs,
-                self.context.cache.local(),
+                &self.context.cache,
                 r_cmd,
                 &configure_args,
                 strip,

--- a/src/sync/sources/url.rs
+++ b/src/sync/sources/url.rs
@@ -4,75 +4,82 @@ use std::sync::Arc;
 
 use fs_err as fs;
 
+use crate::cache::Cache;
 use crate::events;
 use crate::library::LocalMetadata;
-use crate::package::PackageType;
 use crate::sync::LinkMode;
-use crate::sync::errors::SyncError;
-use crate::{Cancellation, DiskCache, RCmd, ResolvedDependency};
+use crate::sync::errors::{SyncError, SyncErrorKind};
+use crate::{Cancellation, RCmd, ResolvedDependency, is_binary_package};
 
 pub(crate) fn install_package(
     pkg: &ResolvedDependency,
     library_dirs: &[&Path],
-    cache: &DiskCache,
+    cache: &Cache,
     r_cmd: &impl RCmd,
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
 ) -> Result<(), SyncError> {
-    let pkg_paths = cache.get_package_paths(&pkg.source, None, None);
-    let download_path = pkg_paths.source.join(pkg.name.as_ref());
+    let (local_paths, global_paths) = cache.get_package_paths(&pkg.source, None, None);
 
-    // If we have a binary, copy it since we don't keep cache around for binary URL packages
-    if pkg.kind == PackageType::Binary {
-        log::debug!(
-            "Package from URL in {} is already a binary",
-            download_path.display()
-        );
-        if !pkg_paths.binary.is_dir() {
+    if !pkg.cache_status.binary_available() {
+        let download_path = local_paths.source.join(pkg.name.as_ref());
+        let is_binary = is_binary_package(&download_path, &pkg.name).map_err(|e| SyncError {
+            source: SyncErrorKind::InvalidPackage {
+                path: download_path.clone(),
+                error: e.to_string(),
+            },
+        })?;
+
+        if is_binary {
+            log::debug!(
+                "Package from URL in {} is already a binary",
+                download_path.display()
+            );
             LinkMode::link_files(
                 Some(LinkMode::Copy),
                 &pkg.name,
-                &pkg_paths.source,
-                &pkg_paths.binary,
+                &local_paths.source,
+                &local_paths.binary,
             )?;
-        }
-    } else {
-        log::debug!(
-            "Building the package from URL in {}",
-            download_path.display()
-        );
-        let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
-            r_cmd.install(
-                &download_path,
-                Option::<&Path>::None,
-                library_dirs,
-                &pkg_paths.binary,
-                cancellation,
-                &pkg.env_vars,
-                configure_args,
-                strip,
-            )
-        })?;
+        } else {
+            log::debug!(
+                "Building the package from URL in {}",
+                download_path.display()
+            );
+            let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
+                r_cmd.install(
+                    &download_path,
+                    Option::<&Path>::None,
+                    library_dirs,
+                    &local_paths.binary,
+                    cancellation,
+                    &pkg.env_vars,
+                    configure_args,
+                    strip,
+                )
+            })?;
 
-        let log_path = cache.get_build_log_path(&pkg.source, None, None);
-        if let Some(parent) = log_path.parent() {
-            fs::create_dir_all(parent)?;
-            let mut f = fs::File::create(log_path)?;
-            f.write_all(output.as_bytes())?;
+            let log_path = cache.local().get_build_log_path(&pkg.source, None, None);
+            if let Some(parent) = log_path.parent() {
+                fs::create_dir_all(parent)?;
+                let mut f = fs::File::create(log_path)?;
+                f.write_all(output.as_bytes())?;
+            }
         }
+
+        let metadata = LocalMetadata::Sha(pkg.source.sha().to_owned());
+        metadata.write(local_paths.binary.join(pkg.name.as_ref()))?;
     }
 
-    let metadata = LocalMetadata::Sha(pkg.source.sha().to_owned());
-    metadata.write(pkg_paths.binary.join(pkg.name.as_ref()))?;
+    let binary_path = if pkg.cache_status.global_binary_available() {
+        global_paths.unwrap().binary
+    } else {
+        local_paths.binary
+    };
 
     // And then we always link the binary folder into the staging library
-    LinkMode::link_files(
-        None,
-        &pkg.name,
-        &pkg_paths.binary,
-        library_dirs.first().unwrap(),
-    )?;
+    LinkMode::link_files(None, &pkg.name, &binary_path, library_dirs.first().unwrap())?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #499

```
❄️  vincent  ~/Code/a2-ai/rv/example_projects/url-dep   url-cache ?   15:06  
 rv plan -vvv
[2026-08-20T13:06:45Z DEBUG rv::r_finder] R in PATH matches: 4.5.3 (use_devel=false)
[2026-08-20T13:06:46Z DEBUG rv::context] Loaded packages db from "/home/vincent/.cache/rv/1501a23f89/4.5/x86_64/zokor/packages.mp"
[2026-08-20T13:06:46Z DEBUG rv::resolver::sat] Solving dependencies for 16 packages and 28 version requirements
[2026-08-20T13:06:46Z DEBUG rv::resolver::sat] Starting SAT solving
[2026-08-20T13:06:46Z INFO  rv::resolver::sat] SAT solving completed in 16.572µs, found 16 packages
[2026-08-20T13:06:46Z INFO  rv::cli::sync] Planned dependencies in 0ms
Nothing to do

❄️  vincent  ~/Code/a2-ai/rv/example_projects/url-dep   url-cache ?   15:07  
 rm -rf rv/library/ && time rv sync
From local cache (16):
  + R6           2.6.1  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + cli          3.6.5  compiled  https://packagemanager.posit.co/cran/2025-05-12                               1ms
  + dplyr        1.1.3  compiled  https://cran.r-project.org/src/contrib/Archive/dplyr/dplyr_1.1.3.tar.gz       0ms
  + fansi        1.0.6  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + generics     0.1.4  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + glue         1.8.0  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + lifecycle    1.0.4  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + magrittr     2.0.3  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + pillar      1.10.2  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + pkgconfig    2.0.3  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + rlang        1.1.6  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + tibble       3.2.1  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + tidyselect   1.2.1  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + utf8         1.2.5  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + vctrs        0.6.5  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms
  + withr        3.0.2  compiled  https://packagemanager.posit.co/cran/2025-05-12                               0ms

sync completed in 32ms (16 installed, 0 removed)

________________________________________________________
Executed in  105.05 millis    fish           external
   usr time   56.11 millis  272.00 micros   55.84 millis
   sys time   36.36 millis  332.00 micros   36.03 millis
```

and if i edit the lockfile manually to change the SHA:
```
 RV_CACHE_DIR=/tmp/rv-cache rv plan
Failed to resolve all dependencies
    dplyr [listed in rproject.toml]: The URL https://cran.r-project.org/src/contrib/Archive/dplyr/dplyr_1.1.3.tar.gz has different content than what is recorded in the lockfile (checksum mismatch). Run `rv upgrade` to accept the new content and update the lockfile.
```