### PR TITLE
Keep R translations in the sandbox

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -20,6 +20,10 @@ use crate::consts::{BASE_PACKAGES, RECOMMENDED_PACKAGES};
 use crate::package::{Package, parse_description_file};
 use crate::sync::LinkMode;
 
+// R ships translations beside its base packages, but it is not returned by
+// installed.packages(priority = "base") and has no Priority field.
+const R_TRANSLATIONS_PACKAGE: &str = "translations";
+
 #[derive(Debug, thiserror::Error)]
 pub enum SandboxErrorKind {
     #[error("IO error: {error} ({path})")]
@@ -120,7 +124,9 @@ pub fn get_packages_to_copy(library: &Path) -> Result<SandboxPackages, SandboxEr
             continue;
         }
         let name = entry.file_name().as_os_str().to_string_lossy().to_string();
-        if !BASE_PACKAGES.contains(&name.as_str()) && !RECOMMENDED_PACKAGES.contains(&name.as_str())
+        if !BASE_PACKAGES.contains(&name.as_str())
+            && !RECOMMENDED_PACKAGES.contains(&name.as_str())
+            && name != R_TRANSLATIONS_PACKAGE
         {
             continue;
         }
@@ -198,6 +204,7 @@ mod tests {
         let library = tempfile::tempdir().unwrap();
         add_package(library.path(), "base", "4.5.0");
         add_package(library.path(), "MASS", "7.3-65");
+        add_package(library.path(), R_TRANSLATIONS_PACKAGE, "4.5.0");
         add_package(library.path(), "leaked", "1.0.0");
 
         let packages = get_packages_to_copy(library.path()).unwrap();
@@ -206,6 +213,12 @@ mod tests {
 
         assert!(out.path().join("base").join("DESCRIPTION").is_file());
         assert!(out.path().join("MASS").join("DESCRIPTION").is_file());
+        assert!(
+            out.path()
+                .join(R_TRANSLATIONS_PACKAGE)
+                .join("DESCRIPTION")
+                .is_file()
+        );
         assert!(!out.path().join("leaked").exists());
     }
 }


### PR DESCRIPTION
## Why

The UAT in #512 showed that `file.exists(file.path(.Library, "translations"))` becomes false after sandbox activation even though the selected R installation provides it.

R installs `translations` beside its base packages, but this special component has no `Priority` field and is not returned by `installed.packages(priority = "base")`. Filtering only through the base and recommended package lists therefore omits it.

## Change

- Include `translations` when the selected R installation provides it.
- Keep it optional so R builds without that component remain supported.
- Extend the existing filtering test to verify that base, recommended, and `translations` content is retained while an unrelated host package is excluded.

## Verification

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

Both pass.
