### PR TITLE
Make rv run sandbox-aware and add --isolated

### DIFF
--- a/.github/scripts/integration.py
+++ b/.github/scripts/integration.py
@@ -40,6 +40,14 @@ def run_examples():
         # This one needs lots of system deps, skipping in CI
         if subfolder == "big":
             continue
+        # Fork pull requests do not receive repository secrets. Run every public
+        # integration project and skip only the example that needs the private key.
+        if (
+            subfolder == "private-git-dep"
+            and os.environ.get("RV_HAS_INTERNAL_SSH_KEY") != "true"
+        ):
+            print("===== Skipping private-git-dep: INTERNAL_SSH_KEY is unavailable =====")
+            continue
         subfolder_path = os.path.join(PARENT_FOLDER, subfolder, "rproject.toml")
         print(f"===== Processing example: {subfolder_path} =====")
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
         run: rustc --version
 
       - uses: r-lib/actions/setup-r@v2
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         with:
           r-version: "4.5"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,8 @@ jobs:
     name: integration-test
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
+    env:
+      RV_HAS_INTERNAL_SSH_KEY: ${{ secrets.INTERNAL_SSH_KEY != '' }}
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -96,12 +98,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up SSH with repository-specific key
+        if: env.RV_HAS_INTERNAL_SSH_KEY == 'true'
         uses: webfactory/ssh-agent@v0.10.0
         with:
           # ssh key that can only be used to get the repo in example_projects/private-git-dep
           ssh-private-key: ${{ secrets.INTERNAL_SSH_KEY }}
 
       - name: Add GitHub to known_hosts
+        if: env.RV_HAS_INTERNAL_SSH_KEY == 'true'
         shell: bash
         run: |
           ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/example_projects/sandbox/rproject.toml
+++ b/example_projects/sandbox/rproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "simple"
+r_version = "4.5"
+sandbox = true
+
+repositories = [
+    {alias = "posit", url = "https://packagemanager.posit.co/cran/2025-05-12/"}
+]
+dependencies = [
+    "dplyr",
+]

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -87,6 +87,18 @@ impl DiskCache {
         })
     }
 
+    /// Where we store sandboxes for projects that opt-in in that behaviour
+    /// The path given should be canonicalized.
+    /// In the end it will look something like:
+    /// `sandboxes/{R install hash}/{R-major.minor}/{arch}/{distro}/{hash of base packages}`
+    pub(super) fn get_sandbox_dir(&self, library_path: &Path) -> PathBuf {
+        let encoded = hash_string(library_path.to_string_lossy().as_ref());
+        self.root
+            .join("sandboxes")
+            .join(&encoded)
+            .join(get_current_system_path(&self.system_info, self.r_version))
+    }
+
     /// PACKAGES databases as well as binary packages are dependent on the OS and R version
     pub(super) fn get_repo_root_binary_dir(&self, name: &str) -> PathBuf {
         let encoded = hash_string(name);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -12,7 +12,7 @@ pub use info::CacheInfo;
 pub use status::{CacheStatus, InstallationStatus};
 use std::collections::HashMap;
 use std::error::Error;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct Cache {
@@ -101,6 +101,15 @@ impl Cache {
 
     pub fn global(&self) -> Option<&DiskCache> {
         self.global.as_ref()
+    }
+
+    pub fn get_sandbox_paths(&self, library_path: &Path) -> (PathBuf, Option<PathBuf>) {
+        let local = self.local.get_sandbox_dir(library_path);
+        let global = self
+            .global
+            .as_ref()
+            .map(|g| g.get_sandbox_dir(library_path));
+        (local, global)
     }
 
     pub fn get_package_paths(

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 
 use crate::cli::{Context, OutputFormat, ResolveMode, resolve_dependencies};
 use crate::sync::OutputSection;
-use crate::{Lockfile, Resolution, SyncChange, SyncHandler, system_req, timeit};
+use crate::{
+    Lockfile, RCmd, Resolution, SyncChange, SyncHandler, ensure_sandbox_exists, system_req, timeit,
+};
 
 #[derive(Debug, Default, Serialize)]
 struct SyncChanges {
@@ -62,6 +64,22 @@ impl SyncHelper {
             return Err(anyhow::anyhow!(
                 "`--locked` requires the lockfile to be enabled in rproject.toml"
             ));
+        }
+
+        // Build and use the sandbox if needed
+        if !self.dry_run && context.config.sandbox_enabled() {
+            let path = context
+                .r_cmd
+                .get_r_library()
+                .map_err(|e| {
+                    anyhow::anyhow!("sandbox is enabled but the R library was not found: {e}")
+                })
+                .and_then(|lib| {
+                    ensure_sandbox_exists(&lib, &context.cache).map_err(|e| {
+                        anyhow::anyhow!("sandbox is enabled but could not be created: {e}")
+                    })
+                })?;
+            log::debug!("sandbox ready at {}", path.display());
         }
 
         let sync_start = std::time::Instant::now();

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -2,15 +2,13 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use fs_err::{self as fs};
 use serde::Serialize;
 
 use crate::cli::{Context, OutputFormat, ResolveMode, resolve_dependencies};
 use crate::sync::OutputSection;
-use crate::{
-    Lockfile, RCmd, Resolution, SyncChange, SyncHandler, ensure_sandbox_exists, system_req, timeit,
-};
+use crate::{Lockfile, Resolution, SyncChange, SyncHandler, system_req, timeit};
 
 #[derive(Debug, Default, Serialize)]
 struct SyncChanges {
@@ -66,19 +64,14 @@ impl SyncHelper {
             ));
         }
 
-        // Build and use the sandbox if needed
-        if !self.dry_run && context.config.sandbox_enabled() {
-            let path = context
-                .r_cmd
-                .get_r_library()
-                .map_err(|e| {
-                    anyhow::anyhow!("sandbox is enabled but the R library was not found: {e}")
-                })
-                .and_then(|lib| {
-                    ensure_sandbox_exists(&lib, &context.cache).map_err(|e| {
-                        anyhow::anyhow!("sandbox is enabled but could not be created: {e}")
-                    })
-                })?;
+        let sandbox = if self.dry_run {
+            None
+        } else {
+            context
+                .sandbox()
+                .context("sandbox is enabled but could not be established")?
+        };
+        if let Some(path) = &sandbox {
             log::debug!("sandbox ready at {}", path.display());
         }
 
@@ -123,6 +116,7 @@ impl SyncHelper {
                     handler.show_progress_bar();
                 }
                 handler.set_uses_lockfile(context.config.use_lockfile());
+                handler.set_sandbox(sandbox);
                 handler.handle(&resolution.found, &context.r_cmd)
             }
         ) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,12 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::SystemInfo;
-use crate::consts::LOCKFILE_NAME;
+use crate::consts::{LOCKFILE_NAME, USE_SANDBOX_ENV_VAR_NAME};
 use crate::dependency_edit::DEFAULT_GIT_SHORTHAND_BASE_URL;
 use crate::git::url::GitUrl;
 use crate::lockfile::Source;
 use crate::package::{Version, deserialize_version, serialize_version};
+use crate::utils::is_env_var_truthy;
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
@@ -361,6 +362,9 @@ pub(crate) struct Project {
     /// Defaults to https://github.com when not specified.
     #[serde(default)]
     git_shorthand_base_url: Option<String>,
+    /// Whether to create a sandbox for that project
+    #[serde(default)]
+    sandbox: Option<bool>,
 }
 
 // That's the way to do it with serde :/
@@ -517,6 +521,12 @@ impl Config {
 
     pub fn use_devel(&self) -> bool {
         self.project.use_devel.unwrap_or(false)
+    }
+
+    pub fn sandbox_enabled(&self) -> bool {
+        self.project
+            .sandbox
+            .unwrap_or_else(|| is_env_var_truthy(USE_SANDBOX_ENV_VAR_NAME))
     }
 
     pub fn use_lockfile(&self) -> bool {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -193,6 +193,27 @@ rv library will not be activated until the issue is resolved. Entering safe mode
 })
 "#;
 
+/// Site profile for the R subprocesses rv spawns while a project has the sandbox enabled.
+pub(crate) const SANDBOX_INSTALL_PROFILE_TEMPLATE: &str = r#"local({
+	# `.libPaths()` is computed before this profile runs, so it still holds the real
+	# system library. Rebinding `.Library` alone does not retroactively remove it —
+	# the search path has to be rebuilt afterwards, which is what drops it.
+	sys_lib <- normalizePath(file.path(R.home(), "library"), mustWork = FALSE)
+	keep <- setdiff(normalizePath(.libPaths(), mustWork = FALSE), sys_lib)
+
+	env <- baseenv()
+	if (bindingIsLocked(".Library", env)) unlockBinding(".Library", env)
+	assign(".Library", "%sandbox path%", envir = env)
+	lockBinding(".Library", env)
+	if (bindingIsLocked(".Library.site", env)) unlockBinding(".Library.site", env)
+	assign(".Library.site", character(), envir = env)
+	lockBinding(".Library.site", env)
+
+	# Appends the freshly bound `.Library`, ie the sandbox, in place of what we dropped.
+	.libPaths(keep, include.site = FALSE)
+})
+"#;
+
 pub(crate) const RVR_FILE_CONTENT: &str = r#".rv <- new.env()
 .rv$config_path <- file.path(normalizePath(getwd()), "rproject.toml")
 .rv$summary <- function(json = FALSE) {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -30,6 +30,7 @@ pub const INSECURE_TLS_ENV_VAR_NAME: &str = "RV_INSECURE";
 pub const LIBRARY_DIR_ENV_VAR_NAME: &str = "RV_LIBRARY_DIR";
 pub const R_BIN_ENV_VAR_NAME: &str = "RV_R_BIN";
 pub const R_VERSION_ENV_VAR_NAME: &str = "RV_R_VERSION";
+pub const USE_SANDBOX_ENV_VAR_NAME: &str = "RV_USE_SANDBOX";
 
 // List obtained from the REPL: `rownames(installed.packages(priority="base"))`
 // Those will have the same version as R
@@ -80,7 +81,7 @@ pub(crate) const ACTIVATE_FILE_TEMPLATE: &str = r#"local({%global wd content%
 	}
 	rv_info <- system2(
 		"%rv command%",
-		c("info", "--library", "--r-version", "--repositories"),
+		c("info", "--library", "--r-version", "--repositories", "--sandbox"),
 		stdout = TRUE
 	)
 	if (!is.null(attr(rv_info, "status"))) {
@@ -137,9 +138,32 @@ rv library will not be activated until the issue is resolved. Entering safe mode
 		dir.create(rv_lib, recursive = TRUE)
 	}
 
+	# System library sandbox: when the project enables it, rv info returns a path
+	# to a library containing only base + recommended packages. Repoint `.Library`
+	# (and empty `.Library.site`) so packages installed in the system library
+	# cannot leak into the project.
+	sandbox <- if (r_match) get_val("sandbox") else character()
+	sandbox_active <- length(sandbox) == 1 && nzchar(sandbox)
+	if (sandbox_active) {
+		sandbox_active <- isTRUE(tryCatch({
+			env <- baseenv()
+			if (bindingIsLocked(".Library", env)) unlockBinding(".Library", env)
+			assign(".Library", sandbox, envir = env)
+			lockBinding(".Library", env)
+			if (bindingIsLocked(".Library.site", env)) unlockBinding(".Library.site", env)
+			assign(".Library.site", character(), envir = env)
+			lockBinding(".Library.site", env)
+			TRUE
+		}, error = function(e) FALSE))
+	}
+
 	.libPaths(rv_lib, include.site = FALSE)
 	Sys.setenv("R_LIBS_USER" = rv_lib)
-	Sys.setenv("R_LIBS_SITE" = rv_lib)
+	Sys.setenv("R_LIBS_SITE" = if (sandbox_active) {
+		paste(rv_lib, sandbox, sep = .Platform$path.sep)
+	} else {
+		rv_lib
+	})
 
 	# Results
 	if (interactive()) {
@@ -154,6 +178,9 @@ rv library will not be activated until the issue is resolved. Entering safe mode
 			),
 			"\n"
 		)
+		if (sandbox_active) {
+			message("rv system library sandbox active:\n  ", sandbox, "\n")
+		}
 		message(
 			if (r_match) {
 				"rv libpaths active!\nlibrary paths: \n"

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,10 +14,12 @@ use crate::events;
 use crate::lockfile::Lockfile;
 use crate::package::Package;
 use crate::r_finder::find_r_install;
+use crate::sandbox::SandboxErrorKind;
 use crate::utils::create_spinner;
 use crate::{
-    Config, DiskCache, GitExecutor, Http, Library, RInstall, Repository, RepositoryDatabase,
-    Resolution, Resolver, SystemInfo, Version, get_package_file_urls, http, system_req,
+    Config, DiskCache, GitExecutor, Http, Library, RCmd, RInstall, Repository, RepositoryDatabase,
+    Resolution, Resolver, SandboxError, SystemInfo, Version, ensure_sandbox_exists,
+    get_package_file_urls, http, system_req,
 };
 
 /// Method on how to find the R Version on the system
@@ -190,6 +192,20 @@ impl Context {
     /// It can be false if the user is using `--r-version` and/or `--r-bin`
     pub fn r_matches_config(&self) -> bool {
         self.config.r_version().hazy_match(&self.r_version)
+    }
+
+    /// The system library sandbox for this project, built if missing.
+    /// Returns `Ok(None)` if the sandbox is not enabled.
+    pub fn sandbox(&self) -> Result<Option<PathBuf>, SandboxError> {
+        if !self.config.sandbox_enabled() {
+            return Ok(None);
+        }
+
+        let library = self.r_cmd.get_r_library().map_err(|e| SandboxError {
+            source: SandboxErrorKind::LibraryNotFound(e),
+        })?;
+
+        Ok(Some(ensure_sandbox_exists(&library, &self.cache)?))
     }
 
     /// Enable progress bar display for long-running operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use package::{
     Dependency, FetchPackage, Operator, Version, VersionRequirement, is_binary_package,
 };
 pub use project_summary::ProjectSummary;
-pub use r_cmd::RCmd;
+pub use r_cmd::{InstallRequest, RCmd};
 pub use r_finder::RInstall;
 pub use renv::RenvLock;
 pub use repository::RepositoryDatabase;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use renv::RenvLock;
 pub use repository::RepositoryDatabase;
 pub use repository_urls::{get_package_file_urls, get_tarball_urls};
 pub use resolver::{Resolution, ResolvedDependency, Resolver, UnresolvedDependency};
-pub use run::{RunError, run};
+pub use run::{RunError, run, run_with_sandbox};
 pub use sandbox::{SandboxError, ensure_sandbox_exists};
 pub use sync::{BuildPlan, BuildStep, LinkMode, SyncChange, SyncHandler};
 pub use system_info::{OsType, SystemInfo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod repository;
 mod repository_urls;
 mod resolver;
 mod run;
+mod sandbox;
 mod sync;
 mod system_info;
 pub mod system_req;
@@ -59,6 +60,7 @@ pub use repository::RepositoryDatabase;
 pub use repository_urls::{get_package_file_urls, get_tarball_urls};
 pub use resolver::{Resolution, ResolvedDependency, Resolver, UnresolvedDependency};
 pub use run::{RunError, run};
+pub use sandbox::{SandboxError, ensure_sandbox_exists};
 pub use sync::{BuildPlan, BuildStep, LinkMode, SyncChange, SyncHandler};
 pub use system_info::{OsType, SystemInfo};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1349,15 +1349,9 @@ fn try_main() -> Result<()> {
                 .run(&context, resolve_mode)?;
             }
 
-            let sandbox = if context.config.sandbox_enabled() {
-                let library = context.r_cmd.get_r_library().map_err(|e| anyhow!("{e}"))?;
-                Some(
-                    ensure_sandbox_exists(&library, &context.cache)
-                        .map_err(|e| anyhow!("sandbox is enabled but could not be created: {e}"))?,
-                )
-            } else {
-                None
-            };
+            let sandbox = context
+                .sandbox()
+                .map_err(|e| anyhow!("sandbox is enabled but could not be established: {e}"))?;
             if isolated && sandbox.is_none() {
                 return Err(anyhow!(
                     "--isolated requires sandboxing to be enabled for the project"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use serde_json::json;
 
 use anyhow::anyhow;
 use log::warn;
-use rv::RCmd;
 use rv::cli::{
     Context, OutputFormat, RCommandLookup, ResolveMode, SyncHelper, export_renv,
     find_r_repositories, init, init_structure, migrate_renv, resolve_dependencies,
@@ -22,8 +21,8 @@ use rv::{AddOptions, FetchPackage, Http, RepositoryOperation as LibRepositoryOpe
 use rv::{
     CacheInfo, Config, GitExecutor, ProjectSummary, RepositoryAction, RepositoryMatcher,
     RepositoryPositioning, RepositoryUpdates, Version, activate, add_packages, deactivate,
-    ensure_sandbox_exists, execute_repository_action, parse_add_package_spec,
-    read_and_verify_config, resolve_add_options_reference_with_executor, system_req,
+    execute_repository_action, parse_add_package_spec, read_and_verify_config,
+    resolve_add_options_reference_with_executor, system_req,
 };
 
 /// rv, the R package manager
@@ -1181,25 +1180,17 @@ fn try_main() -> Result<()> {
             }
             if sandbox {
                 let mut sandbox_out = String::new();
-                if context.config.sandbox_enabled() {
-                    let res = context
-                        .r_cmd
-                        .get_r_library()
-                        .map_err(|e| anyhow!("{e}"))
-                        .and_then(|lib| {
-                            ensure_sandbox_exists(&lib, &context.cache).map_err(|e| anyhow!("{e}"))
-                        });
-                    match res {
-                        Ok(path) => {
-                            let path_str = path.to_string_lossy();
-                            sandbox_out = if cfg!(windows) {
-                                path_str.replace('\\', "/")
-                            } else {
-                                path_str.to_string()
-                            };
-                        }
-                        Err(e) => warn!("could not create sandbox: {e}"),
+                match context.sandbox() {
+                    Ok(Some(path)) => {
+                        let path_str = path.to_string_lossy();
+                        sandbox_out = if cfg!(windows) {
+                            path_str.replace('\\', "/")
+                        } else {
+                            path_str.to_string()
+                        };
                     }
+                    Ok(None) => {}
+                    Err(e) => warn!("could not create sandbox: {e}"),
                 }
                 output.push(("sandbox", sandbox_out));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ pub enum Command {
     #[clap(trailing_var_arg = true)]
     Run {
         /// Do not sync the project library before running the command
-        /// This needs to be the first flag if set
+        /// This must be the last rv option; following values are passed to Rscript
         #[clap(long)]
         no_sync: bool,
         /// Forces the usage of the R at the given path. If it doesn't match the config's R
@@ -1337,7 +1337,21 @@ fn try_main() -> Result<()> {
                 .run(&context, resolve_mode)?;
             }
 
-            let code = rv::run(&context.r_cmd.bin_path, context.library_path(), &args)?;
+            let sandbox = if context.config.sandbox_enabled() {
+                let library = context.r_cmd.get_r_library().map_err(|e| anyhow!("{e}"))?;
+                Some(
+                    ensure_sandbox_exists(&library, &context.cache)
+                        .map_err(|e| anyhow!("sandbox is enabled but could not be created: {e}"))?,
+                )
+            } else {
+                None
+            };
+            let code = rv::run_with_sandbox(
+                &context.r_cmd.bin_path,
+                context.library_path(),
+                sandbox.as_deref(),
+                &args,
+            )?;
             std::process::exit(code);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 
 use anyhow::anyhow;
 use log::warn;
+use rv::RCmd;
 use rv::cli::{
     Context, OutputFormat, RCommandLookup, ResolveMode, SyncHelper, export_renv,
     find_r_repositories, init, init_structure, migrate_renv, resolve_dependencies,
@@ -21,8 +22,8 @@ use rv::{AddOptions, FetchPackage, Http, RepositoryOperation as LibRepositoryOpe
 use rv::{
     CacheInfo, Config, GitExecutor, ProjectSummary, RepositoryAction, RepositoryMatcher,
     RepositoryPositioning, RepositoryUpdates, Version, activate, add_packages, deactivate,
-    execute_repository_action, parse_add_package_spec, read_and_verify_config,
-    resolve_add_options_reference_with_executor, system_req,
+    ensure_sandbox_exists, execute_repository_action, parse_add_package_spec,
+    read_and_verify_config, resolve_add_options_reference_with_executor, system_req,
 };
 
 /// rv, the R package manager
@@ -228,6 +229,10 @@ pub enum Command {
         /// The repositories specified in the config
         #[clap(long)]
         repositories: bool,
+        /// The system library sandbox path, built on demand if missing.
+        /// Prints an empty value when the project does not enable the sandbox
+        #[clap(long)]
+        sandbox: bool,
     },
     /// List the system dependencies needed by the dependency tree.
     /// This is currently only supported on various Linux distributions.
@@ -1146,6 +1151,7 @@ fn try_main() -> Result<()> {
             library,
             r_version,
             repositories,
+            sandbox,
         } => {
             // TODO: handle info, eg need to accumulate fields
             let mut output = Vec::new();
@@ -1172,6 +1178,30 @@ fn try_main() -> Result<()> {
                     .collect::<Vec<_>>()
                     .join(", ");
                 output.push(("repositories", repos));
+            }
+            if sandbox {
+                let mut sandbox_out = String::new();
+                if context.config.sandbox_enabled() {
+                    let res = context
+                        .r_cmd
+                        .get_r_library()
+                        .map_err(|e| anyhow!("{e}"))
+                        .and_then(|lib| {
+                            ensure_sandbox_exists(&lib, &context.cache).map_err(|e| anyhow!("{e}"))
+                        });
+                    match res {
+                        Ok(path) => {
+                            let path_str = path.to_string_lossy();
+                            sandbox_out = if cfg!(windows) {
+                                path_str.replace('\\', "/")
+                            } else {
+                                path_str.to_string()
+                            };
+                        }
+                        Err(e) => warn!("could not create sandbox: {e}"),
+                    }
+                }
+                output.push(("sandbox", sandbox_out));
             }
 
             if output_format.is_json() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,9 @@ pub enum Command {
     /// Run an Rscript command with the project library paths configured
     #[clap(trailing_var_arg = true)]
     Run {
+        /// Ignore site and user .Renviron and .Rprofile startup files
+        #[clap(long)]
+        isolated: bool,
         /// Do not sync the project library before running the command
         /// This must be the last rv option; following values are passed to Rscript
         #[clap(long)]
@@ -477,6 +480,23 @@ fn make_context(
         }
     }
     Ok(context)
+}
+
+fn user_r_startup_is_configured() -> bool {
+    if ["R_ENVIRON", "R_ENVIRON_USER", "R_PROFILE_USER"]
+        .iter()
+        .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+    {
+        return true;
+    }
+    if std::env::current_dir().is_ok_and(|directory| {
+        directory.join(".Renviron").is_file() || directory.join(".Rprofile").is_file()
+    }) {
+        return true;
+    }
+    etcetera::home_dir().is_ok_and(|directory| {
+        directory.join(".Renviron").is_file() || directory.join(".Rprofile").is_file()
+    })
 }
 
 fn try_main() -> Result<()> {
@@ -1308,6 +1328,7 @@ fn try_main() -> Result<()> {
         }
 
         Command::Run {
+            isolated,
             no_sync,
             r_bin,
             r_version,
@@ -1346,10 +1367,21 @@ fn try_main() -> Result<()> {
             } else {
                 None
             };
+            if isolated && sandbox.is_none() {
+                return Err(anyhow!(
+                    "--isolated requires sandboxing to be enabled for the project"
+                ));
+            }
+            if isolated && !output_format.is_json() && user_r_startup_is_configured() {
+                eprintln!(
+                    "warning: --isolated ignores configured R startup files (.Renviron and .Rprofile) because they can change library paths and process state, undermining reproducibility; omit --isolated to load them"
+                );
+            }
             let code = rv::run_with_sandbox(
                 &context.r_cmd.bin_path,
                 context.library_path(),
                 sandbox.as_deref(),
+                isolated,
                 &args,
             )?;
             std::process::exit(code);

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -472,14 +472,11 @@ impl RCmd for RInstall {
             source: LibraryErrorKind::Io(e),
         })?;
 
-        let lib_path = r_home.join("library");
-
-        if lib_path.is_dir() {
-            Ok(lib_path)
-        } else {
-            Err(LibraryError {
+        match r_home.join("library").canonicalize() {
+            Ok(r_lib) if r_lib.is_dir() => Ok(r_lib),
+            _ => Err(LibraryError {
                 source: LibraryErrorKind::NotFound,
-            })
+            }),
         }
     }
 

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 use std::{fs, thread};
 
+use crate::consts::SANDBOX_INSTALL_PROFILE_TEMPLATE;
 use crate::fs::copy_folder;
 use crate::r_finder::RInstall;
 use crate::sync::{LinkError, LinkMode};
@@ -16,6 +17,17 @@ use regex::Regex;
 
 static R_VERSION_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(\d+)\.(\d+)\.(\d+)").unwrap());
+
+/// The variable we will override/clear for build/install
+const RESERVED_R_ENV_VARS: [&str; 7] = [
+    "R_LIBS",
+    "R_LIBS_SITE",
+    "R_LIBS_USER",
+    "R_PROFILE",
+    "R_PROFILE_USER",
+    "R_ENVIRON",
+    "R_ENVIRON_USER",
+];
 
 fn is_r_devel(output: &str) -> bool {
     output.contains("R Under development")
@@ -33,19 +45,27 @@ fn find_r_version(output: &str) -> Option<Version> {
 pub static ACTIVE_R_PROCESS_IDS: LazyLock<Arc<Mutex<HashSet<u32>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(HashSet::new())));
 
+/// Everything `R CMD INSTALL` needs for one package
+pub struct InstallRequest<'a> {
+    /// Directory holding the package source.
+    pub source: &'a Path,
+    /// Subdirectory of `source` to install from
+    pub sub_folder: Option<&'a Path>,
+    pub libraries: &'a [&'a Path],
+    /// Where the built package ends up.
+    pub destination: &'a Path,
+    pub env_vars: &'a HashMap<&'a str, &'a str>,
+    pub configure_args: &'a [String],
+    pub strip: bool,
+    pub sandbox: Option<&'a Path>,
+}
+
 pub trait RCmd: Send + Sync {
     /// Installs a package and returns the combined output of stdout and stderr
-    #[allow(clippy::too_many_arguments)]
     fn install(
         &self,
-        folder: impl AsRef<Path>,
-        sub_folder: Option<impl AsRef<Path>>,
-        libraries: &[impl AsRef<Path>],
-        destination: impl AsRef<Path>,
+        request: InstallRequest<'_>,
         cancellation: Arc<Cancellation>,
-        env_vars: &HashMap<&str, &str>,
-        configure_args: &[String],
-        strip: bool,
     ) -> Result<String, RCmdError>;
 
     /// Runs `R CMD build` on a source directory and returns the path to the resulting tarball.
@@ -56,6 +76,7 @@ pub trait RCmd: Send + Sync {
         libraries: &[impl AsRef<Path>],
         cancellation: Arc<Cancellation>,
         env_vars: &HashMap<&str, &str>,
+        sandbox: Option<&Path>,
     ) -> Result<PathBuf, RCmdError>;
 
     fn get_r_library(&self) -> Result<PathBuf, LibraryError>;
@@ -83,11 +104,145 @@ fn r_library_paths(libraries: &[impl AsRef<Path>]) -> Result<String, std::io::Er
         .join(sep))
 }
 
+/// For the operations we need a dummy empty file and when the sandbox is active a profile
+/// that will enable the sandbox.
+struct StartupFiles {
+    _dir: tempfile::TempDir,
+    empty: PathBuf,
+    profile: PathBuf,
+}
+
+impl StartupFiles {
+    fn with_sandbox(sandbox: &Path) -> Result<Self, std::io::Error> {
+        Self::write(Some(sandbox))
+    }
+
+    /// Startup files that only suppress the host's, with or without a sandbox.
+    fn write(sandbox: Option<&Path>) -> Result<Self, std::io::Error> {
+        let dir = tempfile::tempdir()?;
+
+        let empty = dir.path().join("rv-empty");
+        fs::write(&empty, "")?;
+
+        let profile = dir.path().join("rv-profile.R");
+        let content = sandbox
+            .map(|sandbox| {
+                SANDBOX_INSTALL_PROFILE_TEMPLATE.replace(
+                    "%sandbox path%",
+                    // R wants forward slashes in paths, on Windows too
+                    &sandbox.to_string_lossy().replace('\\', "/"),
+                )
+            })
+            .unwrap_or_default();
+        fs::write(&profile, content)?;
+
+        Ok(Self {
+            _dir: dir,
+            empty,
+            profile,
+        })
+    }
+}
+
+/// We ensure we pass all the needed arguments to isolate properly the calls.
+/// We don't let a user env override one of [RESERVED_R_ENV_VARS] to keep build reproducible.
+fn apply_r_env(
+    command: &mut Command,
+    library_paths: &str,
+    startup: Option<&StartupFiles>,
+    env_vars: &HashMap<&str, &str>,
+) {
+    let overridden = RESERVED_R_ENV_VARS
+        .iter()
+        .filter(|name| env_vars.contains_key(**name))
+        .copied()
+        .collect::<Vec<_>>();
+
+    if !overridden.is_empty() {
+        log::warn!(
+            "The user tried to set {}, which rv controls. Skipping.",
+            overridden.join(", ")
+        );
+    }
+
+    // First user env
+    command.envs(env_vars);
+
+    // then rv
+    command
+        .env("R_LIBS", library_paths)
+        .env("R_LIBS_SITE", library_paths)
+        .env("R_LIBS_USER", library_paths);
+
+    if let Some(startup) = startup {
+        command
+            .env("R_PROFILE", &startup.profile)
+            .env("R_PROFILE_USER", &startup.empty)
+            .env("R_ENVIRON", &startup.empty)
+            .env("R_ENVIRON_USER", &startup.empty);
+    }
+}
+
+/// The setup for `bootstrap.R` scripts
+fn bootstrap_command(
+    r_cmd: &RInstall,
+    script: &str,
+    library_paths: &str,
+    startup: Option<&StartupFiles>,
+    env_vars: &HashMap<&str, &str>,
+) -> Command {
+    let mut command = spawn_r_process_group(r_cmd);
+    if startup.is_none() {
+        command.arg("--vanilla");
+    }
+    command.arg("-f").arg(script);
+    apply_r_env(&mut command, library_paths, startup, env_vars);
+    command
+}
+
+fn install_command(
+    r_cmd: &RInstall,
+    library: &Path,
+    library_paths: &str,
+    startup: Option<&StartupFiles>,
+    env_vars: &HashMap<&str, &str>,
+) -> Command {
+    let mut command = spawn_r_process_group(r_cmd);
+    command
+        .arg("CMD")
+        .arg("INSTALL")
+        // This is where it will be installed
+        .arg(format!("--library={}", library.to_string_lossy()));
+    if startup.is_none() {
+        command.arg("--use-vanilla");
+    }
+    apply_r_env(&mut command, library_paths, startup, env_vars);
+    command
+}
+
+fn build_command(
+    r_cmd: &RInstall,
+    source_dir: &Path,
+    library_paths: &str,
+    startup: &StartupFiles,
+    env_vars: &HashMap<&str, &str>,
+) -> Command {
+    let mut command = spawn_r_process_group(r_cmd);
+    command
+        .arg("CMD")
+        .arg("build")
+        .arg("--no-build-vignettes")
+        .arg("--no-manual")
+        .arg(source_dir);
+    apply_r_env(&mut command, library_paths, Some(startup), env_vars);
+    command
+}
+
 /// By default, doing ctrl+c on rv will kill it as well as all its child process.
 /// To allow graceful shutdown, we create a process group in Unix and the equivalent on Windows
 /// so we can control _how_ they get killed, and allow for a soft cancellation (eg we let
 /// ongoing tasks finish but stop enqueuing/processing new ones.
-fn spawn_isolated_r_command(r_cmd: &RInstall) -> Command {
+fn spawn_r_process_group(r_cmd: &RInstall) -> Command {
     let mut command = Command::new(&r_cmd.bin_path);
 
     #[cfg(unix)]
@@ -229,16 +384,19 @@ pub fn kill_all_r_processes() {
 impl RCmd for RInstall {
     fn install(
         &self,
-        source_folder: impl AsRef<Path>,
-        sub_folder: Option<impl AsRef<Path>>,
-        libraries: &[impl AsRef<Path>],
-        destination: impl AsRef<Path>,
+        request: InstallRequest<'_>,
         cancellation: Arc<Cancellation>,
-        env_vars: &HashMap<&str, &str>,
-        configure_args: &[String],
-        strip: bool,
     ) -> Result<String, RCmdError> {
-        let destination = destination.as_ref();
+        let InstallRequest {
+            source: source_folder,
+            sub_folder,
+            libraries,
+            destination,
+            env_vars,
+            configure_args,
+            strip,
+            sandbox,
+        } = request;
         // We create a temp build dir so we only remove an existing destination if we have something we can replace it with
         let build_dir = tempfile::tempdir().map_err(|e| RCmdError {
             source: RCmdErrorKind::TempDir(e),
@@ -256,7 +414,7 @@ impl RCmd for RInstall {
         LinkMode::link_files(
             Some(LinkMode::Copy),
             "tmp_build",
-            &source_folder,
+            source_folder,
             &src_backup_dir,
         )
         .map_err(|e| RCmdError {
@@ -265,6 +423,13 @@ impl RCmd for RInstall {
 
         let library_paths =
             r_library_paths(libraries).map_err(|e| RCmdError::from_fs_io(e, destination))?;
+
+        let startup_files = sandbox
+            .map(StartupFiles::with_sandbox)
+            .transpose()
+            .map_err(|e| RCmdError {
+                source: RCmdErrorKind::StartupFiles(e),
+            })?;
 
         // Some R package structures, especially those that make use of
         // bootstrap.R like tree-sitter-r require the parent directories
@@ -312,20 +477,15 @@ impl RCmd for RInstall {
 
                 if to_bootstrap {
                     log::debug!("Bootstrapping {}...", destination.display());
-                    // Run bootstrap.R with the same isolation as the build/install step:
-                    // a vanilla R that ignores user/site profiles, the project library
-                    // paths so any `library()` calls resolve against project deps, and the
-                    // package env vars. run_r_command handles pid tracking + cancellation.
-                    let mut command = spawn_isolated_r_command(self);
-                    command
-                        .arg("--vanilla")
-                        .arg("-f")
-                        .arg("bootstrap.R")
-                        .current_dir(&src_backup_dir)
-                        .env("R_LIBS", &library_paths)
-                        .env("R_LIBS_SITE", &library_paths)
-                        .env("R_LIBS_USER", &library_paths)
-                        .envs(env_vars);
+                    // bootstrap.R runs with the same isolation as the install step itself
+                    let mut command = bootstrap_command(
+                        self,
+                        "bootstrap.R",
+                        &library_paths,
+                        startup_files.as_ref(),
+                        env_vars,
+                    );
+                    command.current_dir(&src_backup_dir);
 
                     // Match pkgbuild: a failed bootstrap is a hard build failure rather
                     // than something we silently proceed past.
@@ -340,16 +500,13 @@ impl RCmd for RInstall {
             }
         }
 
-        let mut command = spawn_isolated_r_command(self);
-        command
-            .arg("CMD")
-            .arg("INSTALL")
-            // This is where it will be installed
-            .arg(format!(
-                "--library={}",
-                build_dir.as_ref().to_string_lossy()
-            ))
-            .arg("--use-vanilla");
+        let mut command = install_command(
+            self,
+            build_dir.as_ref(),
+            &library_paths,
+            startup_files.as_ref(),
+            env_vars,
+        );
 
         if strip {
             command.arg("--strip").arg("--strip-lib");
@@ -362,26 +519,19 @@ impl RCmd for RInstall {
             let combined_args = configure_args.join(" ");
             log::debug!(
                 "Adding configure args for {}: {}",
-                source_folder.as_ref().display(),
+                source_folder.display(),
                 combined_args
             );
             command.arg(format!("--configure-args='{}'", combined_args));
         }
-        command
-            .arg(&src_backup_dir)
-            // Override where R should look for deps
-            .env("R_LIBS", &library_paths)
-            .env("R_LIBS_SITE", &library_paths)
-            .env("R_LIBS_USER", &library_paths);
+        command.arg(&src_backup_dir);
 
         if strip {
             command.env("_R_SHLIB_STRIP_", "true");
         }
-
-        command.envs(env_vars);
         log::debug!(
             "Compiling {} with env vars: {}",
-            source_folder.as_ref().display(),
+            source_folder.display(),
             command
                 .get_envs()
                 .map(|(k, v)| format!(
@@ -426,6 +576,7 @@ impl RCmd for RInstall {
         libraries: &[impl AsRef<Path>],
         cancellation: Arc<Cancellation>,
         env_vars: &HashMap<&str, &str>,
+        sandbox: Option<&Path>,
     ) -> Result<PathBuf, RCmdError> {
         let output_dir = output_dir.as_ref();
         let source_dir = source_dir.as_ref();
@@ -433,18 +584,13 @@ impl RCmd for RInstall {
         let library_paths =
             r_library_paths(libraries).map_err(|e| RCmdError::from_fs_io(e, source_dir))?;
 
-        let mut command = spawn_isolated_r_command(self);
-        command
-            .arg("CMD")
-            .arg("build")
-            .arg("--no-build-vignettes")
-            .arg("--no-manual")
-            .arg(source_dir)
-            .current_dir(output_dir)
-            .env("R_LIBS", &library_paths)
-            .env("R_LIBS_SITE", &library_paths)
-            .env("R_LIBS_USER", &library_paths)
-            .envs(env_vars);
+        // `R CMD build` has no `--vanilla`, so we override all the startup files
+        let startup = StartupFiles::write(sandbox).map_err(|e| RCmdError {
+            source: RCmdErrorKind::StartupFiles(e),
+        })?;
+
+        let mut command = build_command(self, source_dir, &library_paths, &startup, env_vars);
+        command.current_dir(output_dir);
 
         log::debug!("Running R CMD build on {}", source_dir.display());
 
@@ -531,6 +677,8 @@ pub enum RCmdErrorKind {
     LinkError(LinkError),
     #[error("Failed to create or copy files to temp directory: {0}")]
     TempDir(std::io::Error),
+    #[error("Failed to write the R startup files used to isolate the subprocess: {0}")]
+    StartupFiles(std::io::Error),
     #[error("Command failed: {0}")]
     Command(std::io::Error),
     #[error(transparent)]
@@ -568,7 +716,7 @@ pub enum VersionErrorKind {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("Failed to get R version")]
+#[error("Failed to locate the R library")]
 #[non_exhaustive]
 pub struct LibraryError {
     pub source: LibraryErrorKind,

--- a/src/r_cmd.rs
+++ b/src/r_cmd.rs
@@ -65,7 +65,7 @@ pub trait RCmd: Send + Sync {
 
 /// Canonicalize library paths and join them into R's expected format
 /// (colon-separated on Unix, semicolon-separated on Windows).
-fn r_library_paths(libraries: &[impl AsRef<Path>]) -> Result<String, std::io::Error> {
+pub(crate) fn r_library_paths(libraries: &[impl AsRef<Path>]) -> Result<String, std::io::Error> {
     let canonicalized = libraries
         .iter()
         .map(|lib| lib.as_ref().canonicalize())

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,28 +1,95 @@
 use std::path::{Path, PathBuf};
 
+use crate::r_cmd::r_library_paths;
+
 /// R environment variables to remove before spawning Rscript.
 /// R_LIBS is cleared so only the project library is used.
 const R_ENV_VARS_TO_REMOVE: &[&str] = &["R_LIBS", "R_INCLUDE_DIR", "R_SHARE_DIR", "R_DOC_DIR"];
+const PROJECT_LIBRARY_ENV_VAR: &str = "RV_PROJECT_LIBRARY";
+const SANDBOX_LIBRARY_ENV_VAR: &str = "RV_SANDBOX_LIBRARY";
+
+const SANDBOX_PROFILE: &str = r#"local({
+	project <- Sys.getenv("RV_PROJECT_LIBRARY", unset = "")
+	sandbox <- Sys.getenv("RV_SANDBOX_LIBRARY", unset = "")
+	if (!nzchar(project) || !dir.exists(project)) {
+		stop("rv project library is unavailable", call. = FALSE)
+	}
+	if (!nzchar(sandbox) || !dir.exists(sandbox)) {
+		stop("rv sandbox is enabled but its library is unavailable", call. = FALSE)
+	}
+	project <- normalizePath(project, winslash = "/", mustWork = TRUE)
+	sandbox <- normalizePath(sandbox, winslash = "/", mustWork = TRUE)
+
+	env <- baseenv()
+	if (bindingIsLocked(".Library", env)) unlockBinding(".Library", env)
+	assign(".Library", sandbox, envir = env)
+	lockBinding(".Library", env)
+	if (bindingIsLocked(".Library.site", env)) unlockBinding(".Library.site", env)
+	assign(".Library.site", character(), envir = env)
+	lockBinding(".Library.site", env)
+
+	.libPaths(c(project, sandbox), include.site = FALSE)
+	paths <- paste(project, sandbox, sep = .Platform$path.sep)
+	Sys.setenv(R_LIBS_USER = paths, R_LIBS_SITE = paths)
+})
+"#;
 
 /// Run `Rscript` with the given arguments and the project library paths configured.
 pub fn run(r_bin_path: &Path, library_path: &Path, args: &[String]) -> Result<i32, RunError> {
+    run_with_sandbox(r_bin_path, library_path, None, args)
+}
+
+/// Run `Rscript` with the project library and optional system-library sandbox.
+///
+/// The sandbox is established by a controlled site profile before R loads the
+/// normal project or user `.Rprofile`.
+pub fn run_with_sandbox(
+    r_bin_path: &Path,
+    library_path: &Path,
+    sandbox_path: Option<&Path>,
+    args: &[String],
+) -> Result<i32, RunError> {
     let r_home = crate::r_cmd::get_r_home(r_bin_path).map_err(|source| RunError::RHome {
         path: r_bin_path.to_path_buf(),
         source,
     })?;
     let rscript = crate::r_cmd::resolve_rscript_path(&r_home);
 
+    let mut libraries = vec![library_path];
+    if let Some(sandbox_path) = sandbox_path {
+        libraries.push(sandbox_path);
+    }
+    let library_paths = r_library_paths(&libraries).map_err(|source| RunError::LibraryPaths {
+        path: library_path.to_path_buf(),
+        source,
+    })?;
+
+    let startup = if sandbox_path.is_some() {
+        let directory = tempfile::tempdir().map_err(|source| RunError::Startup { source })?;
+        std::fs::write(directory.path().join("site.Rprofile"), SANDBOX_PROFILE)
+            .map_err(|source| RunError::Startup { source })?;
+        Some(directory)
+    } else {
+        None
+    };
+
     let mut cmd = std::process::Command::new(&rscript);
     cmd.args(args)
         .env("R_HOME", &r_home)
-        .env("R_LIBS_USER", library_path)
-        .env("R_LIBS_SITE", library_path)
+        .env("R_LIBS_USER", &library_paths)
+        .env("R_LIBS_SITE", &library_paths)
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
 
     for var in R_ENV_VARS_TO_REMOVE {
         cmd.env_remove(var);
+    }
+
+    if let (Some(sandbox_path), Some(startup)) = (sandbox_path, &startup) {
+        cmd.env(PROJECT_LIBRARY_ENV_VAR, library_path)
+            .env(SANDBOX_LIBRARY_ENV_VAR, sandbox_path)
+            .env("R_PROFILE", startup.path().join("site.Rprofile"));
     }
 
     let status = cmd.status().map_err(|source| RunError::Spawn {
@@ -45,4 +112,11 @@ pub enum RunError {
         path: PathBuf,
         source: std::io::Error,
     },
+    #[error("Failed to configure R library paths from {path}: {source}")]
+    LibraryPaths {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("Failed to create controlled R startup files: {source}")]
+    Startup { source: std::io::Error },
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -36,17 +36,19 @@ const SANDBOX_PROFILE: &str = r#"local({
 
 /// Run `Rscript` with the given arguments and the project library paths configured.
 pub fn run(r_bin_path: &Path, library_path: &Path, args: &[String]) -> Result<i32, RunError> {
-    run_with_sandbox(r_bin_path, library_path, None, args)
+    run_with_sandbox(r_bin_path, library_path, None, false, args)
 }
 
 /// Run `Rscript` with the project library and optional system-library sandbox.
 ///
 /// The sandbox is established by a controlled site profile before R loads the
-/// normal project or user `.Rprofile`.
+/// normal project or user `.Rprofile`. In isolated mode, user and site startup
+/// files are suppressed.
 pub fn run_with_sandbox(
     r_bin_path: &Path,
     library_path: &Path,
     sandbox_path: Option<&Path>,
+    isolated: bool,
     args: &[String],
 ) -> Result<i32, RunError> {
     let r_home = crate::r_cmd::get_r_home(r_bin_path).map_err(|source| RunError::RHome {
@@ -67,6 +69,8 @@ pub fn run_with_sandbox(
     let startup = if sandbox_path.is_some() {
         let directory = tempfile::tempdir().map_err(|source| RunError::Startup { source })?;
         std::fs::write(directory.path().join("site.Rprofile"), SANDBOX_PROFILE)
+            .map_err(|source| RunError::Startup { source })?;
+        std::fs::write(directory.path().join("empty"), "")
             .map_err(|source| RunError::Startup { source })?;
         Some(directory)
     } else {
@@ -90,6 +94,12 @@ pub fn run_with_sandbox(
         cmd.env(PROJECT_LIBRARY_ENV_VAR, library_path)
             .env(SANDBOX_LIBRARY_ENV_VAR, sandbox_path)
             .env("R_PROFILE", startup.path().join("site.Rprofile"));
+        if isolated {
+            let empty = startup.path().join("empty");
+            cmd.env("R_ENVIRON", &empty)
+                .env("R_ENVIRON_USER", &empty)
+                .env("R_PROFILE_USER", &empty);
+        }
     }
 
     let status = cmd.status().map_err(|source| RunError::Spawn {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use crate::Cache;
 use crate::consts::{BASE_PACKAGES, RECOMMENDED_PACKAGES};
 use crate::package::{Package, parse_description_file};
-use crate::sync::create_symlink;
+use crate::sync::LinkMode;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SandboxErrorKind {
@@ -54,16 +54,42 @@ impl SandboxPackages {
         result[..10].to_string()
     }
 
-    pub fn symlink_to(&self, path: &Path) -> Result<(), SandboxError> {
+    /// We start with symlinks but it can be an issue on Windows.
+    /// If that doesn't work, then we try hardlinks and copy as last fallback
+    pub fn materialize_to(&self, path: &Path) -> Result<(), SandboxError> {
         // Clear whatever is there first so we have a fresh sandbox
         if path.is_dir() {
             fs::remove_dir_all(path).map_err(SandboxError::file(path))?;
         }
         fs::create_dir_all(path).map_err(SandboxError::file(path))?;
 
+        let mut mode = LinkMode::Symlink;
         for (lib_path, pkg) in &self.packages {
-            let link = path.join(&pkg.name);
-            create_symlink(lib_path, &link).map_err(SandboxError::file(link))?;
+            let dest = path.join(&pkg.name);
+
+            while let Err(error) = mode.link_package_dir(lib_path, &dest) {
+                // A failed attempt can leave a partial result behind
+                if let Ok(meta) = fs::symlink_metadata(&dest)
+                    && meta.is_dir()
+                {
+                    fs::remove_dir_all(&dest).map_err(SandboxError::file(&dest))?;
+                }
+
+                let fallback = match mode {
+                    LinkMode::Symlink => LinkMode::Hardlink,
+                    LinkMode::Hardlink => LinkMode::Copy,
+                    _ => {
+                        return Err(SandboxError::file(dest)(std::io::Error::other(error)));
+                    }
+                };
+                log::warn!(
+                    "Could not {} {} into the sandbox: {error}. Falling back to {}.",
+                    mode.name(),
+                    pkg.name,
+                    fallback.name()
+                );
+                mode = fallback;
+            }
         }
 
         Ok(())
@@ -116,7 +142,7 @@ pub fn ensure_sandbox_exists(library: &Path, cache: &Cache) -> Result<PathBuf, S
 
     fs::create_dir_all(&local).map_err(SandboxError::file(&local))?;
     let tmp = tempfile::tempdir_in(&local).map_err(SandboxError::file(&local))?;
-    content.symlink_to(tmp.path())?;
+    content.materialize_to(tmp.path())?;
 
     for name in BASE_PACKAGES {
         if !tmp.path().join(name).join("DESCRIPTION").is_file() {
@@ -138,5 +164,36 @@ pub fn ensure_sandbox_exists(library: &Path, cache: &Cache) -> Result<PathBuf, S
                 Err(SandboxError::file(sandbox_path)(error))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_package(library: &Path, name: &str, version: &str) {
+        let package = library.join(name);
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("DESCRIPTION"),
+            format!("Package: {name}\nVersion: {version}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn materialize_filters_out_non_builtin_packages() {
+        let library = tempfile::tempdir().unwrap();
+        add_package(library.path(), "base", "4.5.0");
+        add_package(library.path(), "MASS", "7.3-65");
+        add_package(library.path(), "leaked", "1.0.0");
+
+        let packages = get_packages_to_copy(library.path()).unwrap();
+        let out = tempfile::tempdir().unwrap();
+        packages.materialize_to(out.path()).unwrap();
+
+        assert!(out.path().join("base").join("DESCRIPTION").is_file());
+        assert!(out.path().join("MASS").join("DESCRIPTION").is_file());
+        assert!(!out.path().join("leaked").exists());
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,142 @@
+use std::path::{Path, PathBuf};
+
+use fs_err as fs;
+use sha2::{Digest, Sha256};
+
+use crate::Cache;
+use crate::consts::{BASE_PACKAGES, RECOMMENDED_PACKAGES};
+use crate::package::{Package, parse_description_file};
+use crate::sync::create_symlink;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxErrorKind {
+    #[error("IO error: {error} ({path})")]
+    File {
+        error: std::io::Error,
+        path: PathBuf,
+    },
+    #[error("base package `{name}` is missing or broken in the R library ({library})")]
+    MissingBasePackage {
+        name: &'static str,
+        library: PathBuf,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[non_exhaustive]
+pub struct SandboxError {
+    pub source: SandboxErrorKind,
+}
+
+impl SandboxError {
+    /// For use in `map_err` on fs operations, capturing the path involved
+    fn file(path: impl Into<PathBuf>) -> impl FnOnce(std::io::Error) -> Self {
+        let path = path.into();
+        move |error| Self {
+            source: SandboxErrorKind::File { error, path },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SandboxPackages {
+    packages: Vec<(PathBuf, Package)>,
+}
+
+impl SandboxPackages {
+    pub fn sha(&self) -> String {
+        let mut hasher = Sha256::new();
+        for (_, pkg) in &self.packages {
+            hasher.update(format!("{}-{}\n", pkg.name, pkg.version.original));
+        }
+        let result = hex::encode(hasher.finalize());
+        result[..10].to_string()
+    }
+
+    pub fn symlink_to(&self, path: &Path) -> Result<(), SandboxError> {
+        // Clear whatever is there first so we have a fresh sandbox
+        if path.is_dir() {
+            fs::remove_dir_all(path).map_err(SandboxError::file(path))?;
+        }
+        fs::create_dir_all(path).map_err(SandboxError::file(path))?;
+
+        for (lib_path, pkg) in &self.packages {
+            let link = path.join(&pkg.name);
+            create_symlink(lib_path, &link).map_err(SandboxError::file(link))?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn get_packages_to_copy(library: &Path) -> Result<SandboxPackages, SandboxError> {
+    let mut pkgs = Vec::new();
+
+    for entry in fs::read_dir(library).map_err(SandboxError::file(library))? {
+        let entry = entry.map_err(SandboxError::file(library))?;
+
+        let path = entry.path();
+        let description_path = path.join("DESCRIPTION");
+        if !path.is_dir() || !description_path.exists() {
+            continue;
+        }
+        let name = entry.file_name().as_os_str().to_string_lossy().to_string();
+        if !BASE_PACKAGES.contains(&name.as_str()) && !RECOMMENDED_PACKAGES.contains(&name.as_str())
+        {
+            continue;
+        }
+        let content =
+            fs::read_to_string(&description_path).map_err(SandboxError::file(description_path))?;
+        let Some(package) = parse_description_file(&content) else {
+            continue;
+        };
+
+        pkgs.push((entry.path(), package));
+    }
+
+    pkgs.sort_by(|a, b| a.1.name.cmp(&b.1.name));
+    Ok(SandboxPackages { packages: pkgs })
+}
+
+pub fn ensure_sandbox_exists(library: &Path, cache: &Cache) -> Result<PathBuf, SandboxError> {
+    let content = get_packages_to_copy(library)?;
+    let content_sha = content.sha();
+    let (local, global) = cache.get_sandbox_paths(library);
+    if let Some(g) = global {
+        let path = g.join(&content_sha);
+        if path.is_dir() {
+            return Ok(path);
+        }
+    }
+    let sandbox_path = local.join(&content_sha);
+    if sandbox_path.is_dir() {
+        return Ok(sandbox_path);
+    }
+
+    fs::create_dir_all(&local).map_err(SandboxError::file(&local))?;
+    let tmp = tempfile::tempdir_in(&local).map_err(SandboxError::file(&local))?;
+    content.symlink_to(tmp.path())?;
+
+    for name in BASE_PACKAGES {
+        if !tmp.path().join(name).join("DESCRIPTION").is_file() {
+            return Err(SandboxError {
+                source: SandboxErrorKind::MissingBasePackage {
+                    name,
+                    library: library.to_path_buf(),
+                },
+            });
+        }
+    }
+
+    match fs::rename(tmp.path(), &sandbox_path) {
+        Ok(()) => Ok(sandbox_path),
+        Err(error) => {
+            if sandbox_path.is_dir() {
+                Ok(sandbox_path)
+            } else {
+                Err(SandboxError::file(sandbox_path)(error))
+            }
+        }
+    }
+}

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -20,6 +20,10 @@ use crate::consts::{BASE_PACKAGES, RECOMMENDED_PACKAGES};
 use crate::package::{Package, parse_description_file};
 use crate::sync::LinkMode;
 
+// R ships translations beside its base packages, but it is not returned by
+// installed.packages(priority = "base") and has no Priority field.
+const R_TRANSLATIONS_PACKAGE: &str = "translations";
+
 #[derive(Debug, thiserror::Error)]
 pub enum SandboxErrorKind {
     #[error("IO error: {error} ({path})")]
@@ -120,7 +124,9 @@ pub fn get_packages_to_copy(library: &Path) -> Result<SandboxPackages, SandboxEr
             continue;
         }
         let name = entry.file_name().as_os_str().to_string_lossy().to_string();
-        if !BASE_PACKAGES.contains(&name.as_str()) && !RECOMMENDED_PACKAGES.contains(&name.as_str())
+        if !BASE_PACKAGES.contains(&name.as_str())
+            && !RECOMMENDED_PACKAGES.contains(&name.as_str())
+            && name != R_TRANSLATIONS_PACKAGE
         {
             continue;
         }
@@ -198,6 +204,7 @@ mod tests {
         let library = tempfile::tempdir().unwrap();
         add_package(library.path(), "base", "4.5.0");
         add_package(library.path(), "MASS", "7.3-65");
+        add_package(library.path(), R_TRANSLATIONS_PACKAGE, "4.5.0");
         add_package(library.path(), "leaked", "1.0.0");
 
         let packages = get_packages_to_copy(library.path()).unwrap();
@@ -206,6 +213,12 @@ mod tests {
 
         assert!(out.path().join("base").join("DESCRIPTION").is_file());
         assert!(out.path().join("MASS").join("DESCRIPTION").is_file());
+        assert!(
+            out.path()
+                .join(R_TRANSLATIONS_PACKAGE)
+                .join("DESCRIPTION")
+                .is_file()
+        );
         assert!(!out.path().join("leaked").exists());
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -8,8 +8,7 @@
 //! so the sandbox can be shared across projects using the same R.
 //!
 //! The sandbox is an opt-in behaviour at either the config or environment variable level and is
-//! used in the activate script and by `rv run`.
-//! It is not currently used in rv R INSTALL of packages.
+//! used in the activate script, by `rv run`, and while building and installing packages.
 use std::path::{Path, PathBuf};
 
 use fs_err as fs;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,3 +1,15 @@
+//! In some environments, users can install packages directly in R RHOME, leaking packages
+//! into every R sessions so scripts can work locally but break elsewhere because of dependencies
+//! not listed in rproject.toml or rv.lock.
+//! To avoid that, we create sandboxes in the cache where we link the base + recommended packages only
+//! from the given R RHOME. Any user packages will NOT be linked into the sandbox.
+//! The sandbox in the cache is keyed like this:
+//! `caches/rv/sandboxes/{R install hash}/{R-major.minor}/{arch}/{distro}/{hash of base+rec packages}`
+//! so the sandbox can be shared across projects using the same R.
+//!
+//! The sandbox is an opt-in behaviour at either the config or environment variable level and is
+//! used in the activate script.
+//! It is not currently used in rv R INSTALL of packages.
 use std::path::{Path, PathBuf};
 
 use fs_err as fs;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -36,6 +36,8 @@ pub enum SandboxErrorKind {
         name: &'static str,
         library: PathBuf,
     },
+    #[error(transparent)]
+    LibraryNotFound(#[from] crate::r_cmd::LibraryError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -8,7 +8,7 @@
 //! so the sandbox can be shared across projects using the same R.
 //!
 //! The sandbox is an opt-in behaviour at either the config or environment variable level and is
-//! used in the activate script.
+//! used in the activate script and by `rv run`.
 //! It is not currently used in rv R INSTALL of packages.
 use std::path::{Path, PathBuf};
 

--- a/src/sync/handler.rs
+++ b/src/sync/handler.rs
@@ -112,6 +112,7 @@ pub struct SyncHandler<'a> {
     show_progress_bar: bool,
     max_workers: usize,
     uses_lockfile: bool,
+    sandbox: Option<PathBuf>,
 }
 
 impl<'a> SyncHandler<'a> {
@@ -123,6 +124,7 @@ impl<'a> SyncHandler<'a> {
             show_progress_bar: false,
             uses_lockfile: false,
             max_workers: get_max_workers(),
+            sandbox: None,
         }
     }
 
@@ -143,6 +145,11 @@ impl<'a> SyncHandler<'a> {
 
     pub fn set_uses_lockfile(&mut self, uses_lockfile: bool) {
         self.uses_lockfile = uses_lockfile;
+    }
+
+    /// The sandbox every install in this run should resolve against if present.
+    pub fn set_sandbox(&mut self, sandbox: Option<PathBuf>) {
+        self.sandbox = sandbox;
     }
 
     /// Download source tarballs for all Repository dependencies without installing.
@@ -340,6 +347,8 @@ impl<'a> SyncHandler<'a> {
         let configure_args = self.get_configure_args(&dep.name);
         let strip = self.should_strip(&dep.name);
 
+        let sandbox = self.sandbox.as_deref();
+
         match dep.source {
             Source::Repository { .. } => sources::repositories::install_package(
                 dep,
@@ -349,6 +358,7 @@ impl<'a> SyncHandler<'a> {
                 &configure_args,
                 strip,
                 cancellation,
+                sandbox,
             ),
             Source::Git { .. } | Source::RUniverse { .. } => sources::git::install_package(
                 dep,
@@ -359,6 +369,7 @@ impl<'a> SyncHandler<'a> {
                 &configure_args,
                 strip,
                 cancellation,
+                sandbox,
             ),
             Source::Local { .. } => sources::local::install_package(
                 dep,
@@ -369,6 +380,7 @@ impl<'a> SyncHandler<'a> {
                 &configure_args,
                 strip,
                 cancellation,
+                sandbox,
             ),
             Source::Url { .. } => sources::url::install_package(
                 dep,
@@ -378,6 +390,7 @@ impl<'a> SyncHandler<'a> {
                 &configure_args,
                 strip,
                 cancellation,
+                sandbox,
             ),
             Source::Builtin { .. } => Ok(()),
         }
@@ -459,6 +472,10 @@ impl<'a> SyncHandler<'a> {
         deps: &[ResolvedDependency],
         r_cmd: &impl RCmd,
     ) -> Result<Vec<SyncChange>, SyncError> {
+        if let Some(sandbox) = &self.sandbox {
+            log::debug!("installing against sandbox {}", sandbox.display());
+        }
+
         // Clean up at all times, even with a dry run
         let cancellation = Arc::new(Cancellation::default());
 

--- a/src/sync/link.rs
+++ b/src/sync/link.rs
@@ -82,6 +82,19 @@ impl LinkMode {
         }
     }
 
+    /// Link a single package directory to `dest` using this mode, without any fallback.
+    pub(crate) fn link_package_dir(&self, source: &Path, dest: &Path) -> Result<(), LinkError> {
+        match self {
+            LinkMode::Copy => copy_folder(source, dest).map_err(Into::into),
+            LinkMode::Clone => {
+                fs::create_dir_all(dest)?;
+                clone_package(source, dest)
+            }
+            LinkMode::Hardlink => hardlink_package(source, dest),
+            LinkMode::Symlink => create_symlink(source, dest).map_err(LinkError::Io),
+        }
+    }
+
     pub fn link_files(
         selected_mode: Option<Self>,
         package_name: &str,
@@ -203,12 +216,12 @@ fn hardlink_package(source: &Path, library: &Path) -> Result<(), LinkError> {
 }
 
 #[cfg(unix)]
-pub fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
+fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
     std::os::unix::fs::symlink(original, link)
 }
 
 #[cfg(windows)]
-pub fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
+fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
     if original.as_ref().is_dir() {
         std::os::windows::fs::symlink_dir(original, link)
     } else {

--- a/src/sync/link.rs
+++ b/src/sync/link.rs
@@ -203,12 +203,12 @@ fn hardlink_package(source: &Path, library: &Path) -> Result<(), LinkError> {
 }
 
 #[cfg(unix)]
-fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
+pub fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
     std::os::unix::fs::symlink(original, link)
 }
 
 #[cfg(windows)]
-fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
+pub fn create_symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> std::io::Result<()> {
     if original.as_ref().is_dir() {
         std::os::windows::fs::symlink_dir(original, link)
     } else {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -11,4 +11,4 @@ pub use build_plan::{BuildPlan, BuildStep};
 pub use changes::OutputSection;
 pub use changes::SyncChange;
 pub use handler::SyncHandler;
-pub use link::{LinkError, LinkMode, create_symlink};
+pub use link::{LinkError, LinkMode};

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -11,4 +11,4 @@ pub use build_plan::{BuildPlan, BuildStep};
 pub use changes::OutputSection;
 pub use changes::SyncChange;
 pub use handler::SyncHandler;
-pub use link::{LinkError, LinkMode};
+pub use link::{LinkError, LinkMode, create_symlink};

--- a/src/sync/sources/git.rs
+++ b/src/sync/sources/git.rs
@@ -11,7 +11,7 @@ use crate::library::LocalMetadata;
 use crate::lockfile::Source;
 use crate::sync::LinkMode;
 use crate::sync::errors::SyncError;
-use crate::{Cancellation, CommandExecutor, RCmd, ResolvedDependency};
+use crate::{Cancellation, CommandExecutor, InstallRequest, RCmd, ResolvedDependency};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn install_package(
@@ -23,6 +23,7 @@ pub(crate) fn install_package(
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
+    sandbox: Option<&Path>,
 ) -> Result<(), SyncError> {
     let (local_paths, global_paths) = cache.get_package_paths(&pkg.source, None, None);
 
@@ -55,14 +56,17 @@ pub(crate) fn install_package(
 
         let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
             r_cmd.install(
-                &source_path,
-                sub_dir,
-                library_dirs,
-                &local_paths.binary,
+                InstallRequest {
+                    source: &source_path,
+                    sub_folder: sub_dir.map(Path::new),
+                    libraries: library_dirs,
+                    destination: &local_paths.binary,
+                    env_vars: &pkg.env_vars,
+                    configure_args,
+                    strip,
+                    sandbox,
+                },
                 cancellation,
-                &pkg.env_vars,
-                configure_args,
-                strip,
             )
         })?;
 

--- a/src/sync/sources/local.rs
+++ b/src/sync/sources/local.rs
@@ -9,7 +9,7 @@ use crate::library::LocalMetadata;
 use crate::lockfile::Source;
 use crate::sync::LinkMode;
 use crate::sync::errors::SyncError;
-use crate::{Cancellation, DiskCache, RCmd, ResolvedDependency, is_binary_package};
+use crate::{Cancellation, DiskCache, InstallRequest, RCmd, ResolvedDependency, is_binary_package};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn install_package(
@@ -21,6 +21,7 @@ pub(crate) fn install_package(
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
+    sandbox: Option<&Path>,
 ) -> Result<(), SyncError> {
     let (local_path, sha) = match &pkg.source {
         Source::Local { path, sha } => (path, sha.clone()),
@@ -76,6 +77,7 @@ pub(crate) fn install_package(
             library_dirs,
             cancellation.clone(),
             &pkg.env_vars,
+            sandbox,
         )?;
 
         // Untar the built tarball and install from the clean source
@@ -87,14 +89,17 @@ pub(crate) fn install_package(
         log::debug!("Installing built package from {}", source_path.display());
         let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
             r_cmd.install(
-                &source_path,
-                Option::<&Path>::None,
-                library_dirs,
-                library_dirs.first().unwrap(),
+                InstallRequest {
+                    source: &source_path,
+                    sub_folder: None,
+                    libraries: library_dirs,
+                    destination: library_dirs[0],
+                    env_vars: &pkg.env_vars,
+                    configure_args,
+                    strip,
+                    sandbox,
+                },
                 cancellation,
-                &pkg.env_vars,
-                configure_args,
-                strip,
             )
         })?;
 
@@ -109,14 +114,17 @@ pub(crate) fn install_package(
         log::debug!("Installing the local package in {}", actual_path.display());
         let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
             r_cmd.install(
-                &actual_path,
-                Option::<&Path>::None,
-                library_dirs,
-                library_dirs.first().unwrap(),
+                InstallRequest {
+                    source: &actual_path,
+                    sub_folder: None,
+                    libraries: library_dirs,
+                    destination: library_dirs[0],
+                    env_vars: &pkg.env_vars,
+                    configure_args,
+                    strip,
+                    sandbox,
+                },
                 cancellation,
-                &pkg.env_vars,
-                configure_args,
-                strip,
             )
         })?;
 

--- a/src/sync/sources/repositories.rs
+++ b/src/sync/sources/repositories.rs
@@ -15,10 +15,11 @@ use crate::repository_urls::TarballUrls;
 use crate::sync::LinkMode;
 use crate::sync::errors::{SyncError, SyncErrorKind};
 use crate::{
-    Cancellation, HttpDownload, PackagePaths, RCmd, ResolvedDependency, get_tarball_urls,
-    is_binary_package,
+    Cancellation, HttpDownload, InstallRequest, PackagePaths, RCmd, ResolvedDependency,
+    get_tarball_urls, is_binary_package,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn install_package(
     pkg: &ResolvedDependency,
     library_dirs: &[&Path],
@@ -27,6 +28,7 @@ pub(crate) fn install_package(
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
+    sandbox: Option<&Path>,
 ) -> Result<(), SyncError> {
     let (local_paths, global_paths) =
         cache.get_package_paths(&pkg.source, Some(&pkg.name), Some(&pkg.version.original));
@@ -36,14 +38,17 @@ pub(crate) fn install_package(
         log::debug!("Compiling package from {}", source_path.display());
         match events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
             r_cmd.install(
-                &source_path,
-                Option::<&Path>::None,
-                library_dirs,
-                &local_paths.binary,
+                InstallRequest {
+                    source: &source_path,
+                    sub_folder: None,
+                    libraries: library_dirs,
+                    destination: &local_paths.binary,
+                    env_vars: &pkg.env_vars,
+                    configure_args,
+                    strip,
+                    sandbox,
+                },
                 cancellation.clone(),
-                &pkg.env_vars,
-                configure_args,
-                strip,
             )
         }) {
             Ok(output) => {

--- a/src/sync/sources/url.rs
+++ b/src/sync/sources/url.rs
@@ -9,8 +9,9 @@ use crate::events;
 use crate::library::LocalMetadata;
 use crate::sync::LinkMode;
 use crate::sync::errors::{SyncError, SyncErrorKind};
-use crate::{Cancellation, RCmd, ResolvedDependency, is_binary_package};
+use crate::{Cancellation, InstallRequest, RCmd, ResolvedDependency, is_binary_package};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn install_package(
     pkg: &ResolvedDependency,
     library_dirs: &[&Path],
@@ -19,6 +20,7 @@ pub(crate) fn install_package(
     configure_args: &[String],
     strip: bool,
     cancellation: Arc<Cancellation>,
+    sandbox: Option<&Path>,
 ) -> Result<(), SyncError> {
     let (local_paths, global_paths) = cache.get_package_paths(&pkg.source, None, None);
 
@@ -49,14 +51,17 @@ pub(crate) fn install_package(
             );
             let output = events::with_task(crate::sync::tasks::compile_task(&pkg.name), || {
                 r_cmd.install(
-                    &download_path,
-                    Option::<&Path>::None,
-                    library_dirs,
-                    &local_paths.binary,
+                    InstallRequest {
+                        source: &download_path,
+                        sub_folder: None,
+                        libraries: library_dirs,
+                        destination: &local_paths.binary,
+                        env_vars: &pkg.env_vars,
+                        configure_args,
+                        strip,
+                        sandbox,
+                    },
                     cancellation,
-                    &pkg.env_vars,
-                    configure_args,
-                    strip,
                 )
             })?;
 

--- a/tests/cli_run_isolated.rs
+++ b/tests/cli_run_isolated.rs
@@ -86,3 +86,87 @@ fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
     assert_eq!(observed["profile"], "profile-loaded", "{stdout}");
     assert_eq!(observed["environ"], "environ-loaded", "{stdout}");
 }
+
+#[test]
+fn rv_run_isolated_ignores_host_startup_and_library_inputs() {
+    let (project, cache, config) = create_project(true);
+    let host_library = TempDir::new().unwrap();
+    let profile = project.path().join("host.Rprofile");
+    fs::write(
+        &profile,
+        "Sys.setenv(RV_EXPLICIT_PROFILE = 'profile-loaded')\n.libPaths(Sys.getenv('RV_HOST_LIBRARY'))\n",
+    )
+    .unwrap();
+    let environ = project.path().join("host.Renviron");
+    fs::write(&environ, "RV_EXPLICIT_ENVIRON=environ-loaded\n").unwrap();
+
+    let mut command = rv_cmd(&cache, &config);
+    command
+        .current_dir(project.path())
+        .env("R_PROFILE_USER", &profile)
+        .env("R_ENVIRON_USER", &environ)
+        .env("R_LIBS", host_library.path())
+        .env("R_LIBS_USER", host_library.path())
+        .env("R_LIBS_SITE", host_library.path())
+        .env("RV_HOST_LIBRARY", host_library.path())
+        .args([
+            "run",
+            "--isolated",
+            "--no-sync",
+            "-e",
+            r#"cat(
+                paste("library", .Library, sep = "\t"),
+                paste("paths", paste(.libPaths(), collapse = .Platform$path.sep), sep = "\t"),
+                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
+                paste("environ", Sys.getenv("RV_EXPLICIT_ENVIRON"), sep = "\t"),
+                sep = "\n"
+            )"#,
+        ]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let observed = probe_values(&stdout);
+    assert!(observed["library"].contains("sandboxes"), "{stdout}");
+    assert!(observed["paths"].contains("rv/library"), "{stdout}");
+    assert!(observed["paths"].contains("sandboxes"), "{stdout}");
+    assert!(
+        !observed["paths"].contains(host_library.path().to_str().unwrap()),
+        "{stdout}"
+    );
+    assert_eq!(observed["profile"], "", "{stdout}");
+    assert_eq!(observed["environ"], "", "{stdout}");
+    assert!(
+        stderr.contains("--isolated ignores configured R startup files")
+            && stderr.contains("undermining reproducibility")
+            && stderr.contains("omit --isolated to load them"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn isolated_requires_sandboxing() {
+    let (project, cache, config) = create_project(false);
+    let mut command = rv_cmd(&cache, &config);
+    command.current_dir(project.path()).args([
+        "run",
+        "--isolated",
+        "--no-sync",
+        "-e",
+        "cat('unreachable')",
+    ]);
+
+    let output = command.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--isolated requires sandboxing to be enabled"),
+        "{stderr}"
+    );
+}

--- a/tests/cli_run_isolated.rs
+++ b/tests/cli_run_isolated.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
 
+const LIBRARY_PROBE: &str = r#"cat(paste("library", .Library, sep = "\t"), paste("paths", paste(.libPaths(), collapse = .Platform$path.sep), sep = "\t"), paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"), paste("environ", Sys.getenv("RV_EXPLICIT_ENVIRON"), sep = "\t"), sep = "\n")"#;
+
 fn create_project(sandbox: bool) -> (TempDir, TempDir, std::path::PathBuf) {
     let project = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
@@ -58,18 +60,7 @@ fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
         .current_dir(project.path())
         .env("R_PROFILE_USER", &profile)
         .env("R_ENVIRON_USER", &environ)
-        .args([
-            "run",
-            "--no-sync",
-            "-e",
-            r#"cat(
-                paste("library", .Library, sep = "\t"),
-                paste("paths", paste(.libPaths(), collapse = .Platform$path.sep), sep = "\t"),
-                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
-                paste("environ", Sys.getenv("RV_EXPLICIT_ENVIRON"), sep = "\t"),
-                sep = "\n"
-            )"#,
-        ]);
+        .args(["run", "--no-sync", "-e", LIBRARY_PROBE]);
 
     let output = command.output().unwrap();
     assert!(
@@ -83,6 +74,11 @@ fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
     assert!(observed["library"].contains("sandboxes"), "{stdout}");
     assert!(observed["paths"].contains("rv/library"), "{stdout}");
     assert!(observed["paths"].contains("sandboxes"), "{stdout}");
+    assert_eq!(
+        std::env::split_paths(&observed["paths"]).count(),
+        2,
+        "{stdout}"
+    );
     assert_eq!(observed["profile"], "profile-loaded", "{stdout}");
     assert_eq!(observed["environ"], "environ-loaded", "{stdout}");
 }
@@ -109,19 +105,7 @@ fn rv_run_isolated_ignores_host_startup_and_library_inputs() {
         .env("R_LIBS_USER", host_library.path())
         .env("R_LIBS_SITE", host_library.path())
         .env("RV_HOST_LIBRARY", host_library.path())
-        .args([
-            "run",
-            "--isolated",
-            "--no-sync",
-            "-e",
-            r#"cat(
-                paste("library", .Library, sep = "\t"),
-                paste("paths", paste(.libPaths(), collapse = .Platform$path.sep), sep = "\t"),
-                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
-                paste("environ", Sys.getenv("RV_EXPLICIT_ENVIRON"), sep = "\t"),
-                sep = "\n"
-            )"#,
-        ]);
+        .args(["run", "--isolated", "--no-sync", "-e", LIBRARY_PROBE]);
 
     let output = command.output().unwrap();
     assert!(
@@ -136,8 +120,13 @@ fn rv_run_isolated_ignores_host_startup_and_library_inputs() {
     assert!(observed["library"].contains("sandboxes"), "{stdout}");
     assert!(observed["paths"].contains("rv/library"), "{stdout}");
     assert!(observed["paths"].contains("sandboxes"), "{stdout}");
+    assert_eq!(
+        std::env::split_paths(&observed["paths"]).count(),
+        2,
+        "{stdout}"
+    );
     assert!(
-        !observed["paths"].contains(host_library.path().to_str().unwrap()),
+        !observed["paths"].contains(&*host_library.path().file_name().unwrap().to_string_lossy()),
         "{stdout}"
     );
     assert_eq!(observed["profile"], "", "{stdout}");

--- a/tests/cli_run_isolated.rs
+++ b/tests/cli_run_isolated.rs
@@ -1,0 +1,88 @@
+use assert_cmd::cargo;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn create_project(sandbox: bool) -> (TempDir, TempDir, std::path::PathBuf) {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let config = project.path().join("rproject.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"[project]
+name = "test-run-isolated"
+r_version = "4.5"
+sandbox = {sandbox}
+repositories = []
+dependencies = []
+"#
+        ),
+    )
+    .unwrap();
+    (project, cache, config)
+}
+
+fn rv_cmd(cache: &TempDir, config: &std::path::Path) -> assert_cmd::Command {
+    let mut command = cargo::cargo_bin_cmd!();
+    command
+        .env("RV_CACHE_DIR", cache.path())
+        .args(["--config-file", config.to_str().unwrap()]);
+    command
+}
+
+fn probe_values(output: &str) -> HashMap<String, String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            line.split_once('\t')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[test]
+fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
+    let (project, cache, config) = create_project(true);
+    let profile = project.path().join("host.Rprofile");
+    fs::write(
+        &profile,
+        "Sys.setenv(RV_EXPLICIT_PROFILE = 'profile-loaded')\n",
+    )
+    .unwrap();
+    let environ = project.path().join("host.Renviron");
+    fs::write(&environ, "RV_EXPLICIT_ENVIRON=environ-loaded\n").unwrap();
+
+    let mut command = rv_cmd(&cache, &config);
+    command
+        .current_dir(project.path())
+        .env("R_PROFILE_USER", &profile)
+        .env("R_ENVIRON_USER", &environ)
+        .args([
+            "run",
+            "--no-sync",
+            "-e",
+            r#"cat(
+                paste("library", .Library, sep = "\t"),
+                paste("paths", paste(.libPaths(), collapse = .Platform$path.sep), sep = "\t"),
+                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
+                paste("environ", Sys.getenv("RV_EXPLICIT_ENVIRON"), sep = "\t"),
+                sep = "\n"
+            )"#,
+        ]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let observed = probe_values(&stdout);
+    assert!(observed["library"].contains("sandboxes"), "{stdout}");
+    assert!(observed["paths"].contains("rv/library"), "{stdout}");
+    assert!(observed["paths"].contains("sandboxes"), "{stdout}");
+    assert_eq!(observed["profile"], "profile-loaded", "{stdout}");
+    assert_eq!(observed["environ"], "environ-loaded", "{stdout}");
+}

--- a/tests/cli_sandbox.rs
+++ b/tests/cli_sandbox.rs
@@ -1,0 +1,321 @@
+use assert_cmd::cargo;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn create_project(sandbox: Option<bool>) -> (TempDir, TempDir, std::path::PathBuf) {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let config = project.path().join("rproject.toml");
+    let sandbox = sandbox
+        .map(|value| format!("sandbox = {value}\n"))
+        .unwrap_or_default();
+    fs::write(
+        &config,
+        format!(
+            r#"[project]
+name = "test-sandbox"
+r_version = "4.5"
+{sandbox}repositories = []
+dependencies = []
+"#
+        ),
+    )
+    .unwrap();
+    (project, cache, config)
+}
+
+fn rv_cmd(cache: &TempDir, config: &std::path::Path) -> assert_cmd::Command {
+    let mut command = cargo::cargo_bin_cmd!();
+    command.env("RV_CACHE_DIR", cache.path());
+    command.args(["--config-file", config.to_str().unwrap()]);
+    command
+}
+
+fn probe_values(output: &str) -> HashMap<String, String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            line.split_once('\t')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[test]
+fn environment_enables_sandbox_when_config_is_unset() {
+    let (_project, cache, config) = create_project(None);
+    let mut command = rv_cmd(&cache, &config);
+    command.env("RV_USE_SANDBOX", "1");
+    command.args(["info", "--sandbox"]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sandbox = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .strip_prefix("sandbox: ")
+        .unwrap()
+        .to_string();
+    assert!(!sandbox.is_empty());
+    assert!(std::path::Path::new(&sandbox).is_dir());
+}
+
+#[test]
+fn explicit_config_disables_environment_override() {
+    let (_project, cache, config) = create_project(Some(false));
+    let mut command = rv_cmd(&cache, &config);
+    command.env("RV_USE_SANDBOX", "1");
+    command.args(["info", "--sandbox"]);
+
+    let output = command.output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "sandbox:");
+}
+
+#[test]
+fn explicit_config_enables_sandbox_when_environment_is_false() {
+    let (_project, cache, config) = create_project(Some(true));
+    let mut command = rv_cmd(&cache, &config);
+    command.env("RV_USE_SANDBOX", "0");
+    command.args(["info", "--sandbox"]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sandbox = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .strip_prefix("sandbox: ")
+        .unwrap()
+        .to_string();
+    assert!(!sandbox.is_empty());
+    assert!(std::path::Path::new(&sandbox).is_dir());
+}
+
+#[test]
+fn rv_run_uses_sandbox_without_project_activation_profile() {
+    let (project, cache, config) = create_project(Some(true));
+    assert!(!project.path().join(".Rprofile").exists());
+
+    let mut command = rv_cmd(&cache, &config);
+    command.current_dir(project.path());
+    command.args([
+        "run",
+        "--no-sync",
+        "-e",
+        r#"cat(.Library, Sys.getenv("R_LIBS_SITE"), sep = "\n")"#,
+    ]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 2, "unexpected output: {stdout}");
+    assert!(
+        lines[0].contains("sandboxes"),
+        "unexpected .Library: {stdout}"
+    );
+    assert!(
+        lines[1].contains("rv/library") || lines[1].contains("rv\\library"),
+        "project library missing: {stdout}"
+    );
+    assert!(
+        lines[1].contains("sandboxes"),
+        "sandbox missing from R_LIBS_SITE: {stdout}"
+    );
+}
+
+#[test]
+fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
+    let (project, cache, config) = create_project(Some(true));
+    let profile = project.path().join("host.Rprofile");
+    fs::write(
+        &profile,
+        "Sys.setenv(RV_EXPLICIT_PROFILE = 'profile-loaded')\n",
+    )
+    .unwrap();
+
+    let mut command = rv_cmd(&cache, &config);
+    command
+        .current_dir(project.path())
+        .env("R_PROFILE_USER", &profile)
+        .args([
+            "run",
+            "--no-sync",
+            "-e",
+            r#"cat(
+                paste("library", .Library, sep = "\t"),
+                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
+                sep = "\n"
+            )"#,
+        ]);
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let observed = probe_values(&stdout);
+    assert!(observed["library"].contains("sandboxes"), "{stdout}");
+    assert_eq!(observed["profile"], "profile-loaded", "{stdout}");
+}
+
+#[test]
+fn sync_isolates_r_build_and_install_subprocesses() {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let probe = project.path().join("probe");
+    fs::create_dir_all(probe.join("R")).unwrap();
+    fs::write(
+        probe.join("DESCRIPTION"),
+        r#"Package: sandboxprobe
+Version: 0.1.0
+Title: Verify rv Sandbox Isolation
+Description: Records the R library paths observed while installing.
+Authors@R: person("rv", "test", email = "rv@example.com", role = c("aut", "cre"))
+License: MIT
+Encoding: UTF-8
+"#,
+    )
+    .unwrap();
+    fs::write(probe.join("NAMESPACE"), "export(probe)\n").unwrap();
+    fs::write(
+        probe.join("R").join("probe.R"),
+        r#"local({
+    values <- c(
+        library = .Library,
+        site = paste(.Library.site, collapse = .Platform$path.sep),
+        paths = paste(.libPaths(), collapse = .Platform$path.sep),
+        r_libs = Sys.getenv("R_LIBS"),
+        r_libs_site = Sys.getenv("R_LIBS_SITE"),
+        r_libs_user = Sys.getenv("R_LIBS_USER"),
+        r_environ = Sys.getenv("R_ENVIRON"),
+        r_environ_user = Sys.getenv("R_ENVIRON_USER"),
+        r_profile = Sys.getenv("R_PROFILE"),
+        r_profile_user = Sys.getenv("R_PROFILE_USER"),
+        environ_leak = Sys.getenv("RV_HOST_ENVIRON_LEAK"),
+        profile_leak = Sys.getenv("RV_HOST_PROFILE_LEAK")
+    )
+    writeLines(paste(names(values), values, sep = "\t"), Sys.getenv("RV_TEST_OUTPUT"))
+})
+probe <- function() TRUE
+"#,
+    )
+    .unwrap();
+
+    let observed = project.path().join("observed-library-paths.txt");
+    let observed_for_toml = observed.to_string_lossy().replace('\\', "/");
+    let hostile_library = project.path().join("host-library");
+    fs::create_dir(&hostile_library).unwrap();
+    let hostile_library_for_toml = hostile_library.to_string_lossy().replace('\\', "/");
+    let hostile_environ = project.path().join("host.Renviron");
+    fs::write(&hostile_environ, "RV_HOST_ENVIRON_LEAK=environ-loaded\n").unwrap();
+    let hostile_environ_for_toml = hostile_environ.to_string_lossy().replace('\\', "/");
+    let hostile_profile = project.path().join("host.Rprofile");
+    fs::write(
+        &hostile_profile,
+        "Sys.setenv(RV_HOST_PROFILE_LEAK = 'profile-loaded')\n",
+    )
+    .unwrap();
+    let hostile_profile_for_toml = hostile_profile.to_string_lossy().replace('\\', "/");
+    let config = project.path().join("rproject.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"[project]
+name = "test-install-sandbox"
+r_version = "4.5"
+sandbox = true
+repositories = []
+dependencies = [{{ name = "sandboxprobe", path = "probe" }}]
+
+[project.packages_env_vars]
+sandboxprobe = {{
+    RV_TEST_OUTPUT = "{observed_for_toml}",
+    RV_SANDBOX_LIBRARY = "{hostile_library_for_toml}",
+    R_LIBS = "{hostile_library_for_toml}",
+    R_LIBS_SITE = "{hostile_library_for_toml}",
+    R_LIBS_USER = "{hostile_library_for_toml}",
+    R_ENVIRON = "{hostile_environ_for_toml}",
+    R_ENVIRON_USER = "{hostile_environ_for_toml}",
+    R_PROFILE = "{hostile_profile_for_toml}",
+    R_PROFILE_USER = "{hostile_profile_for_toml}"
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    let mut command = rv_cmd(&cache, &config);
+    command.current_dir(project.path());
+    command.arg("sync");
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let observed = fs::read_to_string(observed).unwrap();
+    let values = probe_values(&observed);
+    assert!(
+        values["library"].contains("sandboxes"),
+        "install-time .Library was not sandboxed: {observed}"
+    );
+    assert_eq!(values["site"], "", "unexpected .Library.site: {observed}");
+    assert!(
+        values["paths"].contains("rv/library") || values["paths"].contains("rv\\library"),
+        "project library missing during install: {observed}"
+    );
+    assert!(
+        values["paths"].contains("sandboxes"),
+        "sandbox missing from install-time .libPaths(): {observed}"
+    );
+    assert!(
+        !values["paths"].contains(&hostile_library.to_string_lossy().to_string()),
+        "package environment leaked a host library into .libPaths(): {observed}"
+    );
+    for variable in ["r_libs", "r_libs_site", "r_libs_user"] {
+        assert!(
+            values[variable].contains("rv/library") || values[variable].contains("rv\\library"),
+            "project library missing from {variable}: {observed}"
+        );
+        assert!(
+            values[variable].contains("sandboxes"),
+            "sandbox missing from {variable}: {observed}"
+        );
+        assert!(
+            !values[variable].contains(&hostile_library.to_string_lossy().to_string()),
+            "package environment overrode {variable}: {observed}"
+        );
+    }
+    assert!(values["r_profile"].ends_with(".rv-profile.R"), "{observed}");
+    assert!(
+        values["r_profile_user"].ends_with(".rv-empty-startup"),
+        "{observed}"
+    );
+    assert!(
+        values["r_environ"].ends_with(".rv-empty-startup"),
+        "{observed}"
+    );
+    assert!(
+        values["r_environ_user"].ends_with(".rv-empty-startup"),
+        "{observed}"
+    );
+    assert_eq!(values["environ_leak"], "", "{observed}");
+    assert_eq!(values["profile_leak"], "", "{observed}");
+}

--- a/tests/cli_sandbox.rs
+++ b/tests/cli_sandbox.rs
@@ -153,11 +153,7 @@ fn rv_run_uses_sandbox_and_loads_user_profile_by_default() {
             "run",
             "--no-sync",
             "-e",
-            r#"cat(
-                paste("library", .Library, sep = "\t"),
-                paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"),
-                sep = "\n"
-            )"#,
+            r#"cat(paste("library", .Library, sep = "\t"), paste("profile", Sys.getenv("RV_EXPLICIT_PROFILE"), sep = "\t"), sep = "\n")"#,
         ]);
 
     let output = command.output().unwrap();

--- a/tests/cli_sandbox.rs
+++ b/tests/cli_sandbox.rs
@@ -295,25 +295,35 @@ sandboxprobe = {{
             "project library missing from {variable}: {observed}"
         );
         assert!(
-            values[variable].contains("sandboxes"),
-            "sandbox missing from {variable}: {observed}"
-        );
-        assert!(
             !values[variable].contains(&hostile_library.to_string_lossy().to_string()),
             "package environment overrode {variable}: {observed}"
         );
     }
-    assert!(values["r_profile"].ends_with(".rv-profile.R"), "{observed}");
-    assert!(
-        values["r_profile_user"].ends_with(".rv-empty-startup"),
+    // The sandbox may be added by a controlled profile rather than encoded in
+    // every R_LIBS* variable. What matters is the effective library search path
+    // above and that package-supplied startup paths cannot replace rv's files.
+    assert!(!values["r_profile"].is_empty(), "{observed}");
+    assert!(!values["r_profile_user"].is_empty(), "{observed}");
+    assert!(!values["r_environ"].is_empty(), "{observed}");
+    assert!(!values["r_environ_user"].is_empty(), "{observed}");
+    assert_ne!(
+        values["r_profile"],
+        hostile_profile.to_string_lossy(),
         "{observed}"
     );
-    assert!(
-        values["r_environ"].ends_with(".rv-empty-startup"),
+    assert_ne!(
+        values["r_profile_user"],
+        hostile_profile.to_string_lossy(),
         "{observed}"
     );
-    assert!(
-        values["r_environ_user"].ends_with(".rv-empty-startup"),
+    assert_ne!(
+        values["r_environ"],
+        hostile_environ.to_string_lossy(),
+        "{observed}"
+    );
+    assert_ne!(
+        values["r_environ_user"],
+        hostile_environ.to_string_lossy(),
         "{observed}"
     );
     assert_eq!(values["environ_leak"], "", "{observed}");


### PR DESCRIPTION
## What this contributes

- Establishes the configured sandbox directly in `rv run`, without relying on a generated project `.Rprofile` having been installed or sourced.
- Keeps normal R startup behavior by default: project/user `.Renviron` and `.Rprofile` files still load, matching option B discussed in #402.
- Adds `rv run --isolated` for callers that need startup-independent execution. It suppresses site/user `.Renviron` and `.Rprofile` files and rejects the flag when sandboxing is disabled.
- Warns when `--isolated` ignores configured startup files, explains the reproducibility risk, and tells the user to omit the flag to load them.
- Adds CLI regression tests for both default and isolated behavior.
- Makes integration CI work for fork PRs: all public example projects still run, while only the private-key example is skipped when the repository secret is unavailable. Trusted runs retain the private test.
- Skips the unused R installation in the musl compile-only job.

## Why this is needed

On the current #512 branch, `rv run` sets the project library environment but does not itself activate the sandbox. Without the generated activation `.Rprofile`, R therefore keeps its host `.Library`. That makes the result depend on how the command was launched even though sandboxing is enabled.

This change makes the sandbox boundary explicit inside `rv run`: the project library and rv sandbox are established before user startup code is evaluated. Default mode still permits the usual R customization, avoiding a surprising difference between an interactive R session and `rv run`. The opt-in `--isolated` mode is available when reproducibility is more important than startup customization, because startup files can change library paths, environment variables, and other process state.

| Invocation | rv sandbox | User startup files |
| --- | --- | --- |
| `rv run ...` | Used when enabled | Loaded normally |
| `rv run --isolated ...` | Required and used | Ignored |

## Tests

- default `rv run` uses the project library plus sandbox and still loads explicit `.Renviron`/`.Rprofile` files;
- `--isolated` keeps host `R_LIBS*` and hostile startup changes out of `.Library`/`.libPaths()`;
- `--isolated` reports a clear error when sandboxing is disabled;
- the existing `cli_run` tests continue to pass;
- `cargo test --all-features`: all enabled tests pass;
- `cargo clippy --all-features --all-targets -- -D warnings`: passes;
- all eight GitHub checks pass, including Linux, macOS, and Windows integration.

## Relationship to the sandbox work

This implements the `rv run` option-B direction proposed by @Keats in #402 and is intentionally based on #512. It does not change package installation; that remains separate as requested.

The problem discovery, R/renv analysis, alternative stricter policy, and earlier implementation remain documented in #402 and #403. The broader subprocess regression matrix is proposed separately in #515, and the sandbox translations fix is #514. Keeping those links preserves the technical history while allowing this focused piece to be reviewed and merged through #512.
